### PR TITLE
fix(karrotframe): change display: none to visiblity: hidden in isLoading

### DIFF
--- a/packages/karrotframe/src/navigator/components/Card.scss
+++ b/packages/karrotframe/src/navigator/components/Card.scss
@@ -7,10 +7,6 @@
   height: 100%;
   opacity: 0;
   will-change: opacity;
-
-  &.isLoading {
-    display: none;
-  }
 }
 :global(.kf-cupertino) {
   .cardDim {
@@ -35,7 +31,7 @@
   will-change: transform;
 
   &.isLoading {
-    display: none;
+    visibility: hidden;
   }
 }
 :global(.kf-android) {

--- a/packages/karrotframe/src/navigator/components/Card.tsx
+++ b/packages/karrotframe/src/navigator/components/Card.tsx
@@ -177,7 +177,6 @@ const Card: React.FC<CardProps> = (props) => {
               <div
                 ref={dimRef}
                 className={classnames(styles.cardDim, {
-                  [styles.isLoading]: loading,
                   [styles.isNavbarVisible]: !!screenInstanceOption?.navbar
                     .visible,
                   [styles.isPresent]: props.isPresent,


### PR DESCRIPTION
# 문제

https://github.com/daangn/karrotframe/issues/53#issuecomment-817242268

[keen-slider](https://keen-slider.io/)를 같이 사용하게 될 경우 keen-slider가 제대로 동작하지 않는 이슈가 있습니다. 추후 다른 라이브러리와 함께 사용할 때도 비슷한 이슈가 있을 것 같아 css 속성을 수정하였습니다.

## 해결

- `display: none`을 하면 내부 엘리먼트까지 영향을 미치게 되므로 `<ScreenHelmet />` 렌더링 타이밍 이슈를 해결하기 위한 용도와 동일하게 `visiblity: hidden`으로 수정하였습니다.
- Card.tsx 내부 코드 중 `props.isRoot`가 loading state의 initial state인데, [Card.tsx#L176](https://github.com/daangn/karrotframe/blob/master/packages/karrotframe/src/navigator/components/Card.tsx#L176)의 경우 root가 false이면 loading도 false, 따라서 [Card.tsx#L180](https://github.com/daangn/karrotframe/blob/master/packages/karrotframe/src/navigator/components/Card.tsx#L180) 줄의 코드가 의미가 없다고 판단하여 scss 등 불필요한 코드를 삭제하였습니다.

## 스크린샷

### Before, `display: block;`

![image](https://user-images.githubusercontent.com/48552260/114518697-95e9c200-9c7a-11eb-9bb8-1c120648a375.png)

### After, `visiblity: hidden;`

![ezgif com-gif-maker](https://user-images.githubusercontent.com/48552260/114519094-0395ee00-9c7b-11eb-91af-e8bb02920631.gif)
