### PR TITLE
fix(karrotframe): remove useless div element in TransitionGroup

### DIFF
--- a/packages/karrotframe/src/navigator/Navigator.tsx
+++ b/packages/karrotframe/src/navigator/Navigator.tsx
@@ -397,7 +397,7 @@ const NavigatorScreens: React.FC<NavigatorScreensProps> = (props) => {
       })}
     >
       {props.children}
-      <TransitionGroup>
+      <TransitionGroup component={null}>
         <Observer>
           {() => (
             <>


### PR DESCRIPTION
# 문제가 될 수 있는 부분

[React Transition Group](http://reactcommunity.org/react-transition-group/transition-group#TransitionGroup-props)

![image](https://user-images.githubusercontent.com/48552260/114547115-fd166f00-9c98-11eb-8233-0ffe5eae9412.png)


- karrotframe 내부 [Navigator.tsx#L400](https://github.com/daangn/karrotframe/blob/master/packages/karrotframe/src/navigator/Navigator.tsx#L400)에서 [react-transition-group](https://www.npmjs.com/package/react-transition-group)을 사용하는데 react-transition-group 문서(위 사진)에서 확인할 수 있듯이 `<TransitionGroup />` 컴포넌트는 default `<div />`로 렌더링 된다고 하며, 의도치 않게 css style을 망가뜨릴 수 있다고 합니다.

## 해결

가이드를 따라 component props에 `null`을 주어 안쓰이는 `div` 엘리먼트를 제거하였습니다.

## 스크린샷

### Before, `<TransitionGroup>`

![image](https://user-images.githubusercontent.com/48552260/114547475-71511280-9c99-11eb-8aca-54a78229f5b6.png)


### After, `<TransitionGroup component={null}>`

![image](https://user-images.githubusercontent.com/48552260/114547327-4666be80-9c99-11eb-8890-0cdd0f3d34a6.png)
