### PR TITLE
chore(tabs): Fix typo

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -54,7 +54,7 @@ const App: React.FC = () => {
         {
           key: 'tab_1',
           buttonLabel: 'Tab 1',
-          component: () => <div>Tab 1</div>,
+          render: () => <div>Tab 1</div>,
         },
       ]}
       onTabChange={(key) => {


### PR DESCRIPTION
## 수정 내용
* `@karrotframe/tabs` 를 적용하다보니, 예시에 기재된 props 형태가 mismatch 나는 부분이 있어서 수정했어요.
* #89 에서 `render` -> `component` 로 변경되었던데, 이렇게 변경하실 예정인걸까요?