### PR TITLE
chore(plugin): Remove some methods of hook options that are not supported yet from document

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 3
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     steps:

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -15,9 +15,6 @@ interface Options {
   pop?: (from: string) => void
   push?: (to: string) => void
   replace?: (to: string) => void
-  preventPop?: () => void
-  preventPush?: () => void
-  preventReplace?: () => void
   mapperScreenInstance?: (screenInstance: IScreenInstance) => IScreenInstance
 }
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karrotframe/plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "extension for karrotframe",
   "repository": "https://github.com/daangn/karrotframe",
   "license": "Apache-2.0",


### PR DESCRIPTION
Remove next methods below from api doucment:

- `preventPop`
- `preventPush`
- `preventReplace`

These methods would be supported soon with nextMethods too

- `activatePop`
- `activatePush`
- `activateReplace`