### PR TITLE
Remove function like react hook for executor of plugin and Declare anonymous function as executor of plugin

### DIFF
--- a/packages/navigator/src/__tests__/plugin.test.tsx
+++ b/packages/navigator/src/__tests__/plugin.test.tsx
@@ -186,19 +186,17 @@ test('플러그인을 사용해서 미들웨어의 마지막 단에 가공한 ur
     ctx.options?.push?.(ctx.to)
   }
 
-  const useTestMiddlewarePlugin = (): PluginType => ({
-    lifeCycleHooks: {
-      beforePush: composeMiddlewares<BeforePushType>([
-        modifyUrlMiddleware,
-        loggerMiddleware,
-        redirectMiddleware,
-      ]),
-    },
-  })
-
   const middlewarePlugin: NavigatorPluginType = {
     name: 'middleware-plugin',
-    executor: useTestMiddlewarePlugin,
+    executor: () => ({
+      lifeCycleHooks: {
+        beforePush: composeMiddlewares<BeforePushType>([
+          modifyUrlMiddleware,
+          loggerMiddleware,
+          redirectMiddleware,
+        ]),
+      },
+    }),
   }
 
   const FalsePage: React.FC = () => <div>false</div>

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -215,20 +215,16 @@ const customMiddlewareThird = async (
   await next()
 }
 
-const useMiddlewareLoggerWithPromise = (): PluginType => {
-  return {
-    lifeCycleHooks: {
-      beforePush: composeMiddlewares<BeforePushType>([
-        customMiddlewareFirst,
-        customMiddlewareSecond,
-        customMiddlewareThird,
-      ]),
-    },
-  }
-}
-
 const middlewareLoggerPlugin: NavigatorPluginType = {
   name: 'middlewareLoggerPlugin',
-  executor: useMiddlewareLoggerWithPromise,
+  executor: () => ({
+      lifeCycleHooks: {
+          beforePush: composeMiddlewares<BeforePushType>([
+              customMiddlewareFirst,
+              customMiddlewareSecond,
+              customMiddlewareThird,
+          ]),
+      },
+  }),
 }
 ```

--- a/packages/plugin/src/basics/loggerMiddlewarePlugin.tsx
+++ b/packages/plugin/src/basics/loggerMiddlewarePlugin.tsx
@@ -30,8 +30,9 @@ const customMiddlewareThird = async (
   console.log('after promise in third middleware', ctx.to)
 }
 
-const useLoggerMiddlewareBeforePushPlugin = (): PluginType => {
-  return {
+export const loggerMiddlewareBeforePushPlugin: NavigatorPluginType = {
+  name: 'loggerMiddlewareBeforePushPlugin',
+  executor: () => ({
     lifeCycleHooks: {
       beforePush: composeMiddlewares<BeforePushType>([
         customMiddlewareFirst,
@@ -39,10 +40,5 @@ const useLoggerMiddlewareBeforePushPlugin = (): PluginType => {
         customMiddlewareThird,
       ]),
     },
-  }
-}
-
-export const loggerMiddlewareBeforePushPlugin: NavigatorPluginType = {
-  name: 'loggerMiddlewareBeforePushPlugin',
-  executor: useLoggerMiddlewareBeforePushPlugin,
+  } as PluginType),
 }


### PR DESCRIPTION
`executor` from NavigatorPluginType should return `PluginType` object.

But current name of function could remind of react hook like `useFoo`.

Current function is replaced with anonymous function to avoid such misconception.