### PR TITLE
Reserve space for ScreenHelmet with env(safe-area-inset-top) option to push dim area downward

### DIFF
--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -53,7 +53,10 @@ export const dim = recipe({
   variants: {
     cupertinoAndIsNavbarVisible: {
       true: {
-        top: [`calc(${vars.navbar.height} + env(safe-area-inset-top))`, `calc(${vars.navbar.height} + constant(safe-area-inset-top))`]
+        top: [
+          `calc(${vars.navbar.height} + env(safe-area-inset-top))`,
+          `calc(${vars.navbar.height} + constant(safe-area-inset-top))`,
+        ],
       },
     },
     cupertinoAndIsPresent: {
@@ -121,7 +124,7 @@ export const main = recipe({
       true: {
         paddingTop: [
           `calc(${vars.navbar.height} + env(safe-area-inset-top))`,
-          `calc(${vars.navbar.height} + constant(safe-area-inset-top))`
+          `calc(${vars.navbar.height} + constant(safe-area-inset-top))`,
         ],
       },
     },

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -53,7 +53,7 @@ export const dim = recipe({
   variants: {
     cupertinoAndIsNavbarVisible: {
       true: {
-        top: `calc(${vars.navbar.height} + env(safe-area-inset-top))`
+        top: [`calc(${vars.navbar.height} + env(safe-area-inset-top))`, `calc(${vars.navbar.height} + constant(safe-area-inset-top))`]
       },
     },
     cupertinoAndIsPresent: {
@@ -119,7 +119,10 @@ export const main = recipe({
     },
     cupertinoAndIsNavbarVisible: {
       true: {
-        paddingTop: `calc(${vars.navbar.height} + env(safe-area-inset-top))`,
+        paddingTop: [
+          `calc(${vars.navbar.height} + env(safe-area-inset-top))`,
+          `calc(${vars.navbar.height} + constant(safe-area-inset-top))`
+        ],
       },
     },
     android: {

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -53,7 +53,7 @@ export const dim = recipe({
   variants: {
     cupertinoAndIsNavbarVisible: {
       true: {
-        top: vars.navbar.height,
+        top: `calc(${vars.navbar.height} + env(safe-area-inset-top))`
       },
     },
     cupertinoAndIsPresent: {

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -17,7 +17,6 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
       'constant(safe-area-inset-top) 0 0',
     ],
-    paddingTop: ['env(safe-area-inset-top)', 'constant(safe-area-inset-top)'],
     backgroundColor: vars.backgroundColor,
   },
   variants: {

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -13,7 +13,10 @@ export const container = recipe({
     position: 'absolute',
     width: '100%',
     top: 0,
-    padding: ['env(safe-area-inset-top) 0 0', 'constant(safe-area-inset-top) 0 0'],
+    padding: [
+      'env(safe-area-inset-top) 0 0',
+      'constant(safe-area-inset-top) 0 0',
+    ],
     paddingTop: ['env(safe-area-inset-top)', 'constant(safe-area-inset-top)'],
     backgroundColor: vars.backgroundColor,
   },

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -13,8 +13,8 @@ export const container = recipe({
     position: 'absolute',
     width: '100%',
     top: 0,
-    padding: 'constant(safe-area-inset-top) 0 0',
-    paddingTop: 'env(safe-area-inset-top)',
+    padding: ['env(safe-area-inset-top) 0 0', 'constant(safe-area-inset-top) 0 0'],
+    paddingTop: ['env(safe-area-inset-top)', 'constant(safe-area-inset-top)'],
     backgroundColor: vars.backgroundColor,
   },
   variants: {


### PR DESCRIPTION
- Dim have covered ScreenHelmet in iOS because Dim area did not consider safe-area.

```javascript
top: `calc(${vars.navbar.height} + env(safe-area-inset-top))` 
```

- With this css, margin space from Top area should be reserved with *`PLUS`* `safe-area-inset-top`