### PR TITLE
fix(navigator): Add hideLeftButton option to hide back or close button from navbar

### DIFF
--- a/examples/spec/src/components/_pages/PageScreenHelmet.tsx
+++ b/examples/spec/src/components/_pages/PageScreenHelmet.tsx
@@ -16,6 +16,8 @@ const PageScreenHelmet: React.FC = () => {
   const [visible, setVisible] = useState(true)
   const [shouldPreventSwipeBack, setPreventSwipeBack] = useState(false)
 
+  const [shouldHideLeftButton, setHideLeftButton] = useState(false)
+
   const onTopClick = () => {
     setIsTopClicked(true)
   }
@@ -35,6 +37,7 @@ const PageScreenHelmet: React.FC = () => {
           noBorder={noBorder}
           visible={visible}
           preventSwipeBack={shouldPreventSwipeBack}
+          hideLeftButton={shouldHideLeftButton}
         />
       )}
       <InputGroup>
@@ -102,6 +105,16 @@ const PageScreenHelmet: React.FC = () => {
           checked={shouldPreventSwipeBack}
           onChange={(e) => {
             setPreventSwipeBack(e.target.checked)
+          }}
+        />
+      </InputGroup>
+      <InputGroup>
+        <InputLabel>HIDE LEFT BUTTON</InputLabel>
+        <Checkbox
+          type="checkbox"
+          checked={shouldHideLeftButton}
+          onChange={(e) => {
+            setHideLeftButton(e.target.checked)
           }}
         />
       </InputGroup>

--- a/examples/spec/src/components/_pages/PageScreenHelmet.tsx
+++ b/examples/spec/src/components/_pages/PageScreenHelmet.tsx
@@ -16,7 +16,7 @@ const PageScreenHelmet: React.FC = () => {
   const [visible, setVisible] = useState(true)
   const [shouldPreventSwipeBack, setPreventSwipeBack] = useState(false)
 
-  const [isNoBackButton, setNoBackButton] = useState(false)
+  const [isNoBackButton, setIsNoBackButton] = useState(false)
 
   const onTopClick = () => {
     setIsTopClicked(true)
@@ -114,7 +114,7 @@ const PageScreenHelmet: React.FC = () => {
           type="checkbox"
           checked={isNoBackButton}
           onChange={(e) => {
-            setNoBackButton(e.target.checked)
+            setIsNoBackButton(e.target.checked)
           }}
         />
       </InputGroup>

--- a/examples/spec/src/components/_pages/PageScreenHelmet.tsx
+++ b/examples/spec/src/components/_pages/PageScreenHelmet.tsx
@@ -16,7 +16,7 @@ const PageScreenHelmet: React.FC = () => {
   const [visible, setVisible] = useState(true)
   const [shouldPreventSwipeBack, setPreventSwipeBack] = useState(false)
 
-  const [shouldHideLeftButton, setHideLeftButton] = useState(false)
+  const [isNoBackButton, setNoBackButton] = useState(false)
 
   const onTopClick = () => {
     setIsTopClicked(true)
@@ -37,7 +37,7 @@ const PageScreenHelmet: React.FC = () => {
           noBorder={noBorder}
           visible={visible}
           preventSwipeBack={shouldPreventSwipeBack}
-          hideLeftButton={shouldHideLeftButton}
+          noBackButton={isNoBackButton}
         />
       )}
       <InputGroup>
@@ -109,12 +109,12 @@ const PageScreenHelmet: React.FC = () => {
         />
       </InputGroup>
       <InputGroup>
-        <InputLabel>HIDE LEFT BUTTON</InputLabel>
+        <InputLabel>HIDE BACK BUTTON</InputLabel>
         <Checkbox
           type="checkbox"
-          checked={shouldHideLeftButton}
+          checked={isNoBackButton}
           onChange={(e) => {
-            setHideLeftButton(e.target.checked)
+            setNoBackButton(e.target.checked)
           }}
         />
       </InputGroup>

--- a/examples/with-cra/src/App.tsx
+++ b/examples/with-cra/src/App.tsx
@@ -9,7 +9,7 @@ import {
 
 const App: React.FC = () => {
   return (
-    <Navigator>
+    <Navigator onClose={() => {}}>
       <Screen path="/" component={Home} />
       <Screen path="/page1" component={Page1} />
       <Screen path="/page2" component={Page2} />

--- a/packages/navigator/README.md
+++ b/packages/navigator/README.md
@@ -139,7 +139,8 @@ const MyComponent: React.FC = () => {
         customCloseButton={<div>Close</div>}
         visible={false}
         preventSwipeBack={true}
-        hideLeftButton={true}
+        noBackButton={true}
+        noCloseButton={true}
       />
     </div>
   )

--- a/packages/navigator/README.md
+++ b/packages/navigator/README.md
@@ -139,6 +139,7 @@ const MyComponent: React.FC = () => {
         customCloseButton={<div>Close</div>}
         visible={false}
         preventSwipeBack={true}
+        hideLeftButton={true}
       />
     </div>
   )

--- a/packages/navigator/src/Navigator.tsx
+++ b/packages/navigator/src/Navigator.tsx
@@ -56,9 +56,9 @@ interface INavigatorProps {
   closeButtonAriaLabel?: string
 
   /**
-   * When close button clicked
+   * When close button clicked (required)
    */
-  onClose?: () => void
+  onClose: () => void
 
   /**
    * When navigation depth changed

--- a/packages/navigator/src/ScreenHelmet.tsx
+++ b/packages/navigator/src/ScreenHelmet.tsx
@@ -62,6 +62,10 @@ export interface IScreenHelmetProps {
    * block event when users try to swipe back
    */
   preventSwipeBack?: boolean
+  /**
+   * hide button from leftside of navbar in ScreenHelmet
+   */
+  hideLeftButton?: boolean
 }
 const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
   const {

--- a/packages/navigator/src/ScreenHelmet.tsx
+++ b/packages/navigator/src/ScreenHelmet.tsx
@@ -62,10 +62,16 @@ export interface IScreenHelmetProps {
    * block event when users try to swipe back
    */
   preventSwipeBack?: boolean
+
   /**
-   * hide button from leftside of navbar in ScreenHelmet
+   * hide back button from navbar in ScreenHelmet
    */
-  hideLeftButton?: boolean
+  noBackButton?: boolean
+
+  /**
+   * hide close button from navbar in ScreenHelmet
+   */
+  noCloseButton?: boolean
 }
 const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
   const {

--- a/packages/navigator/src/__tests__/Navigator.test.tsx
+++ b/packages/navigator/src/__tests__/Navigator.test.tsx
@@ -6,6 +6,8 @@ import Screen from '../Screen'
 
 import { useNavigator } from '../useNavigator'
 
+const NOOP = () => {}
+
 test('Navigator 에 선언한 path 로 push 하면 해당 Screen 의 component 를 렌더링한다.', async () => {
   // given
   const MainPage: React.FC = () => {
@@ -37,7 +39,7 @@ test('Navigator 에 선언한 path 로 push 하면 해당 Screen 의 component �
   }
 
   render(
-    <Navigator>
+    <Navigator onClose={NOOP}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -92,7 +94,7 @@ test('Navigator 에 path 를 지정하지 않은 path 를 push 로 이동한 경
   }
 
   render(
-    <Navigator>
+    <Navigator onClose={NOOP}>
       <Screen path="/" component={MainPage} />
       <Screen path="/*" component={Page404} />
     </Navigator>
@@ -152,7 +154,7 @@ test('push 후 pop 을 사용하면 이전 페이지로 이동한다.', async ()
   }
 
   render(
-    <Navigator>
+    <Navigator onClose={NOOP}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -226,7 +228,7 @@ test('send data 후 pop 을 사용하면 데이터를 이전 페이지에서 확
   }
 
   render(
-    <Navigator>
+    <Navigator onClose={NOOP}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>

--- a/packages/navigator/src/__tests__/Navigator.test.tsx
+++ b/packages/navigator/src/__tests__/Navigator.test.tsx
@@ -6,7 +6,7 @@ import Screen from '../Screen'
 
 import { useNavigator } from '../useNavigator'
 
-const NOOP = () => {}
+const noop = () => {}
 
 test('Navigator 에 선언한 path 로 push 하면 해당 Screen 의 component 를 렌더링한다.', async () => {
   // given
@@ -39,7 +39,7 @@ test('Navigator 에 선언한 path 로 push 하면 해당 Screen 의 component �
   }
 
   render(
-    <Navigator onClose={NOOP}>
+    <Navigator onClose={noop}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -94,7 +94,7 @@ test('Navigator 에 path 를 지정하지 않은 path 를 push 로 이동한 경
   }
 
   render(
-    <Navigator onClose={NOOP}>
+    <Navigator onClose={noop}>
       <Screen path="/" component={MainPage} />
       <Screen path="/*" component={Page404} />
     </Navigator>
@@ -154,7 +154,7 @@ test('push 후 pop 을 사용하면 이전 페이지로 이동한다.', async ()
   }
 
   render(
-    <Navigator onClose={NOOP}>
+    <Navigator onClose={noop}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -228,7 +228,7 @@ test('send data 후 pop 을 사용하면 데이터를 이전 페이지에서 확
   }
 
   render(
-    <Navigator onClose={NOOP}>
+    <Navigator onClose={noop}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -8,7 +8,7 @@ import Navigator from '../Navigator'
 import Screen from '../Screen'
 import { useNavigator } from '../useNavigator'
 
-const NOOP = () => {}
+const noop = () => {}
 
 describe('ScreenHelmet - visible: ', () => {
   const renderScreenHelmet = ({
@@ -26,7 +26,7 @@ describe('ScreenHelmet - visible: ', () => {
     }
 
     return render(
-      <Navigator onClose={NOOP}>
+      <Navigator onClose={noop}>
         <Screen path="/" component={Example} />
       </Navigator>
     )
@@ -87,7 +87,7 @@ describe('ScreenHelmet - preventSwipeBack:  ', () => {
     }
 
     return render(
-      <Navigator onClose={NOOP} theme="Cupertino">
+      <Navigator onClose={noop} theme="Cupertino">
         <Screen path="/" component={Example} />
         <Screen path="/another" component={Another} />
       </Navigator>

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -8,6 +8,8 @@ import Navigator from '../Navigator'
 import Screen from '../Screen'
 import { useNavigator } from '../useNavigator'
 
+const NOOP = () => {}
+
 describe('ScreenHelmet - visible: ', () => {
   const renderScreenHelmet = ({
     visible,
@@ -24,7 +26,7 @@ describe('ScreenHelmet - visible: ', () => {
     }
 
     return render(
-      <Navigator>
+      <Navigator onClose={NOOP}>
         <Screen path="/" component={Example} />
       </Navigator>
     )
@@ -85,7 +87,7 @@ describe('ScreenHelmet - preventSwipeBack:  ', () => {
     }
 
     return render(
-      <Navigator theme="Cupertino">
+      <Navigator onClose={NOOP} theme="Cupertino">
         <Screen path="/" component={Example} />
         <Screen path="/another" component={Another} />
       </Navigator>

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -134,18 +134,20 @@ describe('ScreenHelmet - preventSwipeBack:  ', () => {
   })
 })
 
-describe('ScreenHelmet - hideLeftButton: ', () => {
+describe('ScreenHelmet - noBackButton, noCloseButton: ', () => {
   const renderScreenHelmet = ({
-    hideLeftButton,
+    noBackButton,
+    noCloseButton,
   }: {
-    hideLeftButton: boolean
+    noBackButton?: boolean
+    noCloseButton?: boolean
   }): RenderResult => {
     const HomeWithoutButton: FC = (): ReactElement => {
       const { push } = useNavigator()
 
       return (
         <div>
-          <ScreenHelmet hideLeftButton />
+          <ScreenHelmet noCloseButton />
           <button
             onClick={() => {
               push('/another')
@@ -197,7 +199,7 @@ describe('ScreenHelmet - hideLeftButton: ', () => {
 
       return (
         <div>
-          <ScreenHelmet hideLeftButton />
+          <ScreenHelmet noBackButton />
           <span>another</span>
           <button
             onClick={() => {
@@ -218,40 +220,37 @@ describe('ScreenHelmet - hideLeftButton: ', () => {
         backButtonAriaLabel="BackButtonTest"
         closeButtonAriaLabel="CloseButtonTest"
       >
-        <Screen
-          path="/"
-          component={hideLeftButton ? HomeWithoutButton : Home}
-        />
+        <Screen path="/" component={noCloseButton ? HomeWithoutButton : Home} />
         <Screen
           path="/another"
-          component={hideLeftButton ? AnotherWithoutButton : Another}
+          component={noBackButton ? AnotherWithoutButton : Another}
         />
       </Navigator>
     )
   }
 
-  it('hideLeftButton 가 false 이면, root 에서 close button 이 나타난다.', () => {
+  it('noCloseButton 가 false 이면, root 에서 close button 이 나타난다.', () => {
     // when
-    const { getByLabelText } = renderScreenHelmet({ hideLeftButton: false })
+    const { getByLabelText } = renderScreenHelmet({ noCloseButton: false })
 
     // then
     const closeButtonNotRendering = getByLabelText('CloseButtonTest')
     expect(closeButtonNotRendering).toBeInTheDocument()
   })
 
-  it('hideLeftButton 가 true 이면, root 에서 close button 이 나타나지 않는다.', () => {
+  it('noCloseButton 가 true 이면, root 에서 close button 이 나타나지 않는다.', () => {
     // when
-    const { queryByLabelText } = renderScreenHelmet({ hideLeftButton: true })
+    const { queryByLabelText } = renderScreenHelmet({ noCloseButton: true })
 
     // then
     const closeButtonNotRendering = queryByLabelText('CloseButtonTest')
     expect(closeButtonNotRendering).not.toBeInTheDocument()
   })
 
-  it('hideLeftButton 가 false 이면, root 가 아닐 때 back button 이 나타난다.', async () => {
+  it('noBackButton 가 false 이면, root 가 아닐 때 back button 이 나타난다.', async () => {
     // given
     const { findByLabelText, getByText, findByText } = renderScreenHelmet({
-      hideLeftButton: false,
+      noBackButton: false,
     })
 
     try {
@@ -272,10 +271,10 @@ describe('ScreenHelmet - hideLeftButton: ', () => {
     }
   })
 
-  it('hideLeftButton 가 true 이면, root 가 아닐 때 back button 이 나타나지 않는다.', async () => {
+  it('noBackButton 가 true 이면, root 가 아닐 때 back button 이 나타나지 않는다.', async () => {
     // given
-    const { queryByLabelText, getByText, findByText } = renderScreenHelmet({
-      hideLeftButton: true,
+    const { getByText, findByText, findByLabelText } = renderScreenHelmet({
+      noBackButton: true,
     })
 
     try {
@@ -283,12 +282,10 @@ describe('ScreenHelmet - hideLeftButton: ', () => {
       const moveButton = getByText(/move/i)
       fireEvent.click(moveButton)
 
-      // use waitFor to avoid warning message 'When testing, code that causes React state updates should be wrapped into act
-      await waitFor(() => {
-        // then
-        const closeButtonNotRendering = queryByLabelText('BackButtonTest')
-        expect(closeButtonNotRendering).not.toBeInTheDocument()
-      })
+      // then
+      await expect(
+        findByLabelText('BackButtonTest', {}, { timeout: 300 })
+      ).rejects.toThrow()
     } finally {
       // use waitFor to avoid warning message 'When testing, code that causes React state updates should be wrapped into act
       await waitFor(async () => {

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -133,3 +133,169 @@ describe('ScreenHelmet - preventSwipeBack:  ', () => {
     expect(edgeElement).toBeInTheDocument()
   })
 })
+
+describe('ScreenHelmet - hideLeftButton: ', () => {
+  const renderScreenHelmet = ({
+    hideLeftButton,
+  }: {
+    hideLeftButton: boolean
+  }): RenderResult => {
+    const HomeWithoutButton: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet hideLeftButton />
+          <button
+            onClick={() => {
+              push('/another')
+            }}
+          >
+            move
+          </button>
+        </div>
+      )
+    }
+
+    const Home: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet />
+          <button
+            onClick={() => {
+              push('/another')
+            }}
+          >
+            move
+          </button>
+        </div>
+      )
+    }
+
+    const Another: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet />
+          <span>another</span>
+          <button
+            onClick={() => {
+              push('/')
+            }}
+          >
+            teardown
+          </button>
+        </div>
+      )
+    }
+
+    const AnotherWithoutButton: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet hideLeftButton />
+          <span>another</span>
+          <button
+            onClick={() => {
+              push('/')
+            }}
+          >
+            teardown
+          </button>
+        </div>
+      )
+    }
+
+    return render(
+      <Navigator
+        onClose={() => {
+          console.log('ScreenHelmet test')
+        }}
+        backButtonAriaLabel="BackButtonTest"
+        closeButtonAriaLabel="CloseButtonTest"
+      >
+        <Screen
+          path="/"
+          component={hideLeftButton ? HomeWithoutButton : Home}
+        />
+        <Screen
+          path="/another"
+          component={hideLeftButton ? AnotherWithoutButton : Another}
+        />
+      </Navigator>
+    )
+  }
+
+  it('hideLeftButton 가 false 이면, root 에서 close button 이 나타난다.', () => {
+    // when
+    const { getByLabelText } = renderScreenHelmet({ hideLeftButton: false })
+
+    // then
+    const closeButtonNotRendering = getByLabelText('CloseButtonTest')
+    expect(closeButtonNotRendering).toBeInTheDocument()
+  })
+
+  it('hideLeftButton 가 true 이면, root 에서 close button 이 나타나지 않는다.', () => {
+    // when
+    const { queryByLabelText } = renderScreenHelmet({ hideLeftButton: true })
+
+    // then
+    const closeButtonNotRendering = queryByLabelText('CloseButtonTest')
+    expect(closeButtonNotRendering).not.toBeInTheDocument()
+  })
+
+  it('hideLeftButton 가 false 이면, root 가 아닐 때 back button 이 나타난다.', async () => {
+    // given
+    const { findByLabelText, getByText, findByText } = renderScreenHelmet({
+      hideLeftButton: false,
+    })
+
+    try {
+      // when
+      const moveButton = getByText(/move/i)
+      fireEvent.click(moveButton)
+
+      // then
+      const closeButtonNotRendering = await findByLabelText('BackButtonTest')
+      expect(closeButtonNotRendering).toBeInTheDocument()
+    } finally {
+      // use waitFor to avoid warning message 'When testing, code that causes React state updates should be wrapped into act
+      await waitFor(async () => {
+        // teardown
+        const teardownButton = await findByText('teardown')
+        fireEvent.click(teardownButton)
+      })
+    }
+  })
+
+  it('hideLeftButton 가 true 이면, root 가 아닐 때 back button 이 나타나지 않는다.', async () => {
+    // given
+    const { queryByLabelText, getByText, findByText } = renderScreenHelmet({
+      hideLeftButton: true,
+    })
+
+    try {
+      // when
+      const moveButton = getByText(/move/i)
+      fireEvent.click(moveButton)
+
+      // use waitFor to avoid warning message 'When testing, code that causes React state updates should be wrapped into act
+      await waitFor(() => {
+        // then
+        const closeButtonNotRendering = queryByLabelText('BackButtonTest')
+        expect(closeButtonNotRendering).not.toBeInTheDocument()
+      })
+    } finally {
+      // use waitFor to avoid warning message 'When testing, code that causes React state updates should be wrapped into act
+      await waitFor(async () => {
+        // teardown
+        const teardownButton = await findByText('teardown')
+        fireEvent.click(teardownButton)
+      })
+    }
+  })
+})

--- a/packages/navigator/src/__tests__/plugin.test.tsx
+++ b/packages/navigator/src/__tests__/plugin.test.tsx
@@ -14,6 +14,7 @@ import type {
 import { composeMiddlewares } from '@karrotframe/navigator-plugin'
 
 const Page404: React.FC = () => <div>Not Found</div>
+const NOOP = () => {}
 
 test('인터페이스에 맞게 플러그인을 선언하면 정상적으로 렌더링한다.', () => {
   // given
@@ -56,7 +57,7 @@ test('인터페이스에 맞게 플러그인을 선언하면 정상적으로 렌
 
   // when
   render(
-    <Navigator plugins={[simplePlugin]}>
+    <Navigator onClose={NOOP} plugins={[simplePlugin]}>
       <Screen path="/" component={SamplePage} />
     </Navigator>
   )
@@ -137,7 +138,7 @@ test('플러그인의 hook 에서 얻은 정보로 컴포넌트를 업데이트�
   }
 
   render(
-    <Navigator plugins={[simplePlugin]}>
+    <Navigator onClose={NOOP} plugins={[simplePlugin]}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -233,7 +234,7 @@ test('플러그인을 사용해서 미들웨어의 마지막 단에 가공한 ur
   }
 
   render(
-    <Navigator plugins={[middlewarePlugin]}>
+    <Navigator onClose={NOOP} plugins={[middlewarePlugin]}>
       <Screen path="/" component={Main} />
       <Screen path="/false-url" component={FalsePage} />
       <Screen path="/correct-url" component={CorrectPage} />
@@ -367,7 +368,7 @@ test('2개 이상의 플러그인을 조합해서 사용할 수 있다.', async 
   }
 
   render(
-    <Navigator plugins={[simplePlugin, middlewarePlugin]}>
+    <Navigator onClose={NOOP} plugins={[simplePlugin, middlewarePlugin]}>
       <Screen path="/" component={Main} />
       <Screen path="/false-url" component={FalsePage} />
       <Screen path="/correct-url" component={CorrectPage} />
@@ -456,7 +457,7 @@ test('플러그인을 2개 이상 사용할 때 플러그인을 배열에 선언
 
   // when
   render(
-    <Navigator plugins={[firstPlugin, secondPlugin]}>
+    <Navigator onClose={NOOP} plugins={[firstPlugin, secondPlugin]}>
       <Screen path="/" component={MainPage} />
       <Screen path="/move" component={MainPage} />
       <Screen path="/first-url" component={FirstPage} />

--- a/packages/navigator/src/__tests__/plugin.test.tsx
+++ b/packages/navigator/src/__tests__/plugin.test.tsx
@@ -14,7 +14,7 @@ import type {
 import { composeMiddlewares } from '@karrotframe/navigator-plugin'
 
 const Page404: React.FC = () => <div>Not Found</div>
-const NOOP = () => {}
+const noop = () => {}
 
 test('인터페이스에 맞게 플러그인을 선언하면 정상적으로 렌더링한다.', () => {
   // given
@@ -57,7 +57,7 @@ test('인터페이스에 맞게 플러그인을 선언하면 정상적으로 렌
 
   // when
   render(
-    <Navigator onClose={NOOP} plugins={[simplePlugin]}>
+    <Navigator onClose={noop} plugins={[simplePlugin]}>
       <Screen path="/" component={SamplePage} />
     </Navigator>
   )
@@ -138,7 +138,7 @@ test('플러그인의 hook 에서 얻은 정보로 컴포넌트를 업데이트�
   }
 
   render(
-    <Navigator onClose={NOOP} plugins={[simplePlugin]}>
+    <Navigator onClose={noop} plugins={[simplePlugin]}>
       <Screen path="/" component={MainPage} />
       <Screen path="/target-page" component={TargetPage} />
     </Navigator>
@@ -234,7 +234,7 @@ test('플러그인을 사용해서 미들웨어의 마지막 단에 가공한 ur
   }
 
   render(
-    <Navigator onClose={NOOP} plugins={[middlewarePlugin]}>
+    <Navigator onClose={noop} plugins={[middlewarePlugin]}>
       <Screen path="/" component={Main} />
       <Screen path="/false-url" component={FalsePage} />
       <Screen path="/correct-url" component={CorrectPage} />
@@ -368,7 +368,7 @@ test('2개 이상의 플러그인을 조합해서 사용할 수 있다.', async 
   }
 
   render(
-    <Navigator onClose={NOOP} plugins={[simplePlugin, middlewarePlugin]}>
+    <Navigator onClose={noop} plugins={[simplePlugin, middlewarePlugin]}>
       <Screen path="/" component={Main} />
       <Screen path="/false-url" component={FalsePage} />
       <Screen path="/correct-url" component={CorrectPage} />
@@ -457,7 +457,7 @@ test('플러그인을 2개 이상 사용할 때 플러그인을 배열에 선언
 
   // when
   render(
-    <Navigator onClose={NOOP} plugins={[firstPlugin, secondPlugin]}>
+    <Navigator onClose={noop} plugins={[firstPlugin, secondPlugin]}>
       <Screen path="/" component={MainPage} />
       <Screen path="/move" component={MainPage} />
       <Screen path="/first-url" component={FirstPage} />

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -21,7 +21,7 @@ interface ICardProps {
   transitionState: 'idle' | 'enter-active' | 'exit-active'
   backButtonAriaLabel: string
   closeButtonAriaLabel: string
-  onClose?: () => void
+  onClose: () => void
 }
 const Card: React.FC<ICardProps> = (props) => {
   const { shouldAnimate } = useAnimationContext()

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -70,7 +70,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
   const closeButton =
     props.onClose &&
     props.isRoot &&
-    !screenHelmetProps.hideLeftButton &&
+    !screenHelmetProps.noCloseButton &&
     (screenHelmetProps.customCloseButton ? (
       <a
         className={css.closeButton}
@@ -93,7 +93,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
 
   const backButton =
     !props.isRoot &&
-    !screenHelmetProps.hideLeftButton &&
+    !screenHelmetProps.noBackButton &&
     (screenHelmetProps.customBackButton ? (
       <a
         className={css.backButton}

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -17,7 +17,7 @@ interface INavbarProps {
   backButtonAriaLabel: string
   closeButtonAriaLabel: string
   onTopClick: () => void
-  onClose?: () => void
+  onClose: () => void
 }
 const Navbar: React.FC<INavbarProps> = (props) => {
   const { pop } = useNavigator()

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -70,6 +70,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
   const closeButton =
     props.onClose &&
     props.isRoot &&
+    !screenHelmetProps.hideLeftButton &&
     (screenHelmetProps.customCloseButton ? (
       <a
         className={css.closeButton}
@@ -92,6 +93,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
 
   const backButton =
     !props.isRoot &&
+    !screenHelmetProps.hideLeftButton &&
     (screenHelmetProps.customBackButton ? (
       <a
         className={css.backButton}

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -21,7 +21,8 @@ export function makeScreenHelmetDefaultProps(): IScreenHelmetProps {
     noBorder: false,
     onTopClick: undefined,
     preventSwipeBack: false,
-    hideLeftButton: false,
+    noBackButton: false,
+    noCloseButton: false,
   }
 }
 

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -21,6 +21,7 @@ export function makeScreenHelmetDefaultProps(): IScreenHelmetProps {
     noBorder: false,
     onTopClick: undefined,
     preventSwipeBack: false,
+    hideLeftButton: false,
   }
 }
 

--- a/packages/navigator/src/components/Stack.tsx
+++ b/packages/navigator/src/components/Stack.tsx
@@ -30,7 +30,7 @@ interface IStackProps {
   animationDuration: number
   backButtonAriaLabel: string
   closeButtonAriaLabel: string
-  onClose?: () => void
+  onClose: () => void
   onDepthChange?: (depth: number) => void
 }
 const Stack: React.FC<IStackProps> = (props) => {


### PR DESCRIPTION
## `hideLeftButton`

- Add `hideLeftButton` option to hide close button or back button
- This option would cover close button and back button both from left side of navbar, therefore this options get `hideLeftButton` instead of `hideCloseButton` or `hideBackButton`