### PR TITLE
fix(navigator): Add visible option for ScreenHelmet and preventSwipeBack option

### DIFF
--- a/examples/spec/src/components/_pages/PageScreenHelmet.tsx
+++ b/examples/spec/src/components/_pages/PageScreenHelmet.tsx
@@ -13,6 +13,9 @@ const PageScreenHelmet: React.FC = () => {
   const [noBorder, setNoBorder] = useState(false)
   const [noScreenHelmet, setNoScreenHelmet] = useState(false)
 
+  const [visible, setVisible] = useState(true)
+  const [shouldPreventBackSwipe, setPreventBackSwipe] = useState(false)
+
   const onTopClick = () => {
     setIsTopClicked(true)
   }
@@ -30,6 +33,8 @@ const PageScreenHelmet: React.FC = () => {
           appendLeft={appendLeft}
           appendRight={<div onClick={onRightClick}>{appendRight}</div>}
           noBorder={noBorder}
+          visible={visible}
+          preventBackSwipe={shouldPreventBackSwipe}
         />
       )}
       <InputGroup>
@@ -77,6 +82,26 @@ const PageScreenHelmet: React.FC = () => {
           checked={noBorder}
           onChange={(e) => {
             setNoBorder(e.target.checked)
+          }}
+        />
+      </InputGroup>
+      <InputGroup>
+        <InputLabel>VISIBILITY FOR NAVBAR</InputLabel>
+        <Checkbox
+          type="checkbox"
+          checked={visible}
+          onChange={(e) => {
+            setVisible(e.target.checked)
+          }}
+        />
+      </InputGroup>
+      <InputGroup>
+        <InputLabel>PREVENT BACK SWIPE</InputLabel>
+        <Checkbox
+          type="checkbox"
+          checked={shouldPreventBackSwipe}
+          onChange={(e) => {
+            setPreventBackSwipe(e.target.checked)
           }}
         />
       </InputGroup>

--- a/examples/spec/src/components/_pages/PageScreenHelmet.tsx
+++ b/examples/spec/src/components/_pages/PageScreenHelmet.tsx
@@ -14,7 +14,7 @@ const PageScreenHelmet: React.FC = () => {
   const [noScreenHelmet, setNoScreenHelmet] = useState(false)
 
   const [visible, setVisible] = useState(true)
-  const [shouldPreventBackSwipe, setPreventBackSwipe] = useState(false)
+  const [shouldPreventSwipeBack, setPreventSwipeBack] = useState(false)
 
   const onTopClick = () => {
     setIsTopClicked(true)
@@ -34,7 +34,7 @@ const PageScreenHelmet: React.FC = () => {
           appendRight={<div onClick={onRightClick}>{appendRight}</div>}
           noBorder={noBorder}
           visible={visible}
-          preventBackSwipe={shouldPreventBackSwipe}
+          preventSwipeBack={shouldPreventSwipeBack}
         />
       )}
       <InputGroup>
@@ -96,12 +96,12 @@ const PageScreenHelmet: React.FC = () => {
         />
       </InputGroup>
       <InputGroup>
-        <InputLabel>PREVENT BACK SWIPE</InputLabel>
+        <InputLabel>PREVENT SWIPE TO GO BACK</InputLabel>
         <Checkbox
           type="checkbox"
-          checked={shouldPreventBackSwipe}
+          checked={shouldPreventSwipeBack}
           onChange={(e) => {
-            setPreventBackSwipe(e.target.checked)
+            setPreventSwipeBack(e.target.checked)
           }}
         />
       </InputGroup>

--- a/packages/navigator/README.md
+++ b/packages/navigator/README.md
@@ -138,7 +138,7 @@ const MyComponent: React.FC = () => {
         customBackButton={<div>Back</div>}
         customCloseButton={<div>Close</div>}
         visible={false}
-        preventBackSwipe={true}
+        preventSwipeBack={true}
       />
     </div>
   )

--- a/packages/navigator/README.md
+++ b/packages/navigator/README.md
@@ -137,6 +137,8 @@ const MyComponent: React.FC = () => {
         appendRight={<div>Append to Right</div>}
         customBackButton={<div>Back</div>}
         customCloseButton={<div>Close</div>}
+        visible={false}
+        preventBackSwipe={true}
       />
     </div>
   )

--- a/packages/navigator/src/ScreenHelmet.tsx
+++ b/packages/navigator/src/ScreenHelmet.tsx
@@ -61,7 +61,7 @@ export interface IScreenHelmetProps {
   /**
    * block event when users try to swipe back
    */
-  preventSwipeBack?: boolean
+  preventBackSwipe?: boolean
 }
 const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
   const {

--- a/packages/navigator/src/ScreenHelmet.tsx
+++ b/packages/navigator/src/ScreenHelmet.tsx
@@ -52,6 +52,16 @@ export interface IScreenHelmetProps {
    * When top part clicked (iOS Only)
    */
   onTopClick?: () => void
+
+  /**
+   * Set visibility for NavBar (default: `true`)
+   */
+  visible?: boolean
+
+  /**
+   * block event when users try to swipe back
+   */
+  preventSwipeBack?: boolean
 }
 const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
   const {
@@ -68,7 +78,7 @@ const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
         {}
       ),
     })
-    setScreenHelmetVisible(true)
+    setScreenHelmetVisible(props.visible ?? true)
   }, [props])
 
   useEffect(() => resetScreenHelmetProps, [resetScreenHelmetProps])

--- a/packages/navigator/src/ScreenHelmet.tsx
+++ b/packages/navigator/src/ScreenHelmet.tsx
@@ -61,7 +61,7 @@ export interface IScreenHelmetProps {
   /**
    * block event when users try to swipe back
    */
-  preventBackSwipe?: boolean
+  preventSwipeBack?: boolean
 }
 const ScreenHelmet: React.FC<IScreenHelmetProps> = (props) => {
   const {

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -43,18 +43,18 @@ describe('ScreenHelmet - visible: ', () => {
   })
 })
 
-describe('ScreenHelmet - preventBackSwipe:  ', () => {
+describe('ScreenHelmet - preventSwipeBack:  ', () => {
   const renderScreenHelmet = ({
-    preventBackSwipe,
+    preventSwipeBack,
   }: {
-    preventBackSwipe: boolean
+    preventSwipeBack: boolean
   }): RenderResult => {
     const Example: FC = (): ReactElement => {
       const { push } = useNavigator()
 
       return (
         <div>
-          <ScreenHelmet preventBackSwipe={preventBackSwipe} />
+          <ScreenHelmet preventSwipeBack={preventSwipeBack} />
           <span>example</span>
           <button
             onClick={() => {
@@ -71,7 +71,7 @@ describe('ScreenHelmet - preventBackSwipe:  ', () => {
 
       return (
         <div>
-          <ScreenHelmet preventBackSwipe={preventBackSwipe} />
+          <ScreenHelmet preventSwipeBack={preventSwipeBack} />
           <span>another</span>
           <button
             onClick={() => {
@@ -105,10 +105,10 @@ describe('ScreenHelmet - preventBackSwipe:  ', () => {
     }
   })
 
-  it('preventBackSwipe: true 이면 edge element 를 생성하지 않는다 ', async () => {
+  it('preventSwipeBack: true 이면 edge element 를 생성하지 않는다 ', async () => {
     // when
     const { getByText, queryByTestId } = renderScreenHelmet({
-      preventBackSwipe: true,
+      preventSwipeBack: true,
     })
     const moveButton = getByText(/move/i)
     fireEvent.click(moveButton)
@@ -120,10 +120,10 @@ describe('ScreenHelmet - preventBackSwipe:  ', () => {
     })
   })
 
-  it('preventBackSwipe: false 이면 edge element 를 생성한다. ', async () => {
+  it('preventSwipeBack: false 이면 edge element 를 생성한다. ', async () => {
     // when
     const { getByText, findByTestId } = renderScreenHelmet({
-      preventBackSwipe: false,
+      preventSwipeBack: false,
     })
     const moveButton = getByText(/move/i)
     fireEvent.click(moveButton)

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -32,13 +32,13 @@ describe('ScreenHelmet - visible: ', () => {
 
   it('visible: false 이면 navbar 가 나타나지 않는다', () => {
     const { queryByTestId } = renderScreenHelmet({ visible: false })
-    const navBar = queryByTestId('nav-bar')
+    const navBar = queryByTestId('navbar')
     expect(navBar).not.toBeInTheDocument()
   })
 
   it('visible: true 이면 navbar 가 나타난다', () => {
     const { getByTestId } = renderScreenHelmet({ visible: true })
-    const navBar = getByTestId('nav-bar')
+    const navBar = getByTestId('navbar')
     expect(navBar).toBeVisible()
   })
 })

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import type { FC, ReactElement } from 'react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import type { RenderResult } from '@testing-library/react'
+
+import ScreenHelmet from '../ScreenHelmet'
+import Navigator from '../Navigator'
+import Screen from '../Screen'
+import { useNavigator } from '../useNavigator'
+
+describe('ScreenHelmet - visible: ', () => {
+  const renderScreenHelmet = ({
+    visible,
+  }: {
+    visible: boolean
+  }): RenderResult => {
+    const Example: FC = (): ReactElement => {
+      return (
+        <div>
+          <ScreenHelmet visible={visible} />
+          <span>example</span>
+        </div>
+      )
+    }
+
+    return render(
+      <Navigator>
+        <Screen path="/" component={Example} />
+      </Navigator>
+    )
+  }
+
+  it('visible: false 이면 navbar 가 나타나지 않는다', () => {
+    const { queryByTestId } = renderScreenHelmet({ visible: false })
+    const navBar = queryByTestId('nav-bar')
+    expect(navBar).not.toBeInTheDocument()
+  })
+
+  it('visible: true 이면 navbar 가 나타난다', () => {
+    const { getByTestId } = renderScreenHelmet({ visible: true })
+    const navBar = getByTestId('nav-bar')
+    expect(navBar).toBeVisible()
+  })
+})
+
+describe('ScreenHelmet - preventBackSwipe:  ', () => {
+  const renderScreenHelmet = ({
+    preventBackSwipe,
+  }: {
+    preventBackSwipe: boolean
+  }): RenderResult => {
+    const Example: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet preventBackSwipe={preventBackSwipe} />
+          <span>example</span>
+          <button
+            onClick={() => {
+              push('/another')
+            }}
+          >
+            move
+          </button>
+        </div>
+      )
+    }
+    const Another: FC = (): ReactElement => {
+      const { push } = useNavigator()
+
+      return (
+        <div>
+          <ScreenHelmet preventBackSwipe={preventBackSwipe} />
+          <span>another</span>
+          <button
+            onClick={() => {
+              push('/')
+            }}
+          >
+            teardown
+          </button>
+        </div>
+      )
+    }
+
+    return render(
+      <Navigator theme="Cupertino">
+        <Screen path="/" component={Example} />
+        <Screen path="/another" component={Another} />
+      </Navigator>
+    )
+  }
+
+  afterEach(async () => {
+    try {
+      await waitFor(() => {
+        const teardownButton = screen.queryByText(/teardown/i)
+        if (teardownButton) {
+          fireEvent.click(teardownButton)
+        }
+      })
+    } catch (e) {
+      console.error(e)
+    }
+  })
+
+  it('preventBackSwipe: true 이면 edge element 를 생성하지 않는다 ', async () => {
+    // when
+    const { getByText, queryByTestId } = renderScreenHelmet({
+      preventBackSwipe: true,
+    })
+    const moveButton = getByText(/move/i)
+    fireEvent.click(moveButton)
+
+    // then
+    await waitFor(() => {
+      const edgeElement = queryByTestId('edge-element')
+      expect(edgeElement).not.toBeInTheDocument()
+    })
+  })
+
+  it('preventBackSwipe: false 이면 edge element 를 생성한다. ', async () => {
+    // when
+    const { getByText, findByTestId } = renderScreenHelmet({
+      preventBackSwipe: false,
+    })
+    const moveButton = getByText(/move/i)
+    fireEvent.click(moveButton)
+
+    // then
+    const edgeElement = await findByTestId('edge-element')
+    expect(edgeElement).toBeInTheDocument()
+  })
+})

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -65,8 +65,6 @@ const Card: React.FC<ICardProps> = (props) => {
     })
 
     const onTouchStart = (e: TouchEvent) => {
-      if (screenHelmetProps.preventBackSwipe) return
-
       document.activeElement?.['blur']?.()
       x0 = x = e.touches[0].clientX
       t0 = Date.now()
@@ -110,15 +108,7 @@ const Card: React.FC<ICardProps> = (props) => {
       $edge.removeEventListener('touchmove', onTouchMove)
       $edge.removeEventListener('touchend', onTouchEnd)
     }
-  }, [
-    dimRef,
-    frameRef,
-    frameOffsetRef,
-    edgeRef,
-    setPopped,
-    pop,
-    screenHelmetProps.preventBackSwipe,
-  ])
+  }, [dimRef, frameRef, frameOffsetRef, edgeRef, setPopped, pop])
 
   const onTopClick = useCallback(() => {
     const $frame = frameRef.current
@@ -225,16 +215,20 @@ const Card: React.FC<ICardProps> = (props) => {
               {props.children}
             </div>
           </div>
-          {cupertino && !props.isRoot && !props.isPresent && !popped && (
-            <div
-              className={css.edge({
-                cupertinoAndIsNavbarVisible:
-                  cupertino && isNavbarVisible ? true : undefined,
-                isNavbarVisible: isNavbarVisible ? true : undefined,
-              })}
-              ref={edgeRef}
-            />
-          )}
+          {cupertino &&
+            !props.isRoot &&
+            !props.isPresent &&
+            !popped &&
+            !screenHelmetProps.preventBackSwipe && (
+              <div
+                className={css.edge({
+                  cupertinoAndIsNavbarVisible:
+                    cupertino && isNavbarVisible ? true : undefined,
+                  isNavbarVisible: isNavbarVisible ? true : undefined,
+                })}
+                ref={edgeRef}
+              />
+            )}
         </div>
       </div>
     </div>

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -115,7 +115,7 @@ const Card: React.FC<ICardProps> = (props) => {
     edgeRef,
     setPopped,
     pop,
-    screenHelmetProps.preventBackSwipe,
+    screenHelmetProps.preventSwipeBack,
   ])
 
   const onTopClick = useCallback(() => {
@@ -227,7 +227,7 @@ const Card: React.FC<ICardProps> = (props) => {
             !props.isRoot &&
             !props.isPresent &&
             !popped &&
-            !screenHelmetProps.preventBackSwipe && (
+            !screenHelmetProps.preventSwipeBack && (
               <div
                 data-testid="edge-element"
                 className={css.edge({

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -229,6 +229,7 @@ const Card: React.FC<ICardProps> = (props) => {
             !popped &&
             !screenHelmetProps.preventBackSwipe && (
               <div
+                data-testid="edge-element"
                 className={css.edge({
                   cupertinoAndIsNavbarVisible:
                     cupertino && isNavbarVisible ? true : undefined,

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -108,7 +108,15 @@ const Card: React.FC<ICardProps> = (props) => {
       $edge.removeEventListener('touchmove', onTouchMove)
       $edge.removeEventListener('touchend', onTouchEnd)
     }
-  }, [dimRef, frameRef, frameOffsetRef, edgeRef, setPopped, pop])
+  }, [
+    dimRef,
+    frameRef,
+    frameOffsetRef,
+    edgeRef,
+    setPopped,
+    pop,
+    screenHelmetProps.preventBackSwipe,
+  ])
 
   const onTopClick = useCallback(() => {
     const $frame = frameRef.current

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -65,7 +65,7 @@ const Card: React.FC<ICardProps> = (props) => {
     })
 
     const onTouchStart = (e: TouchEvent) => {
-      if (screenHelmetProps.preventSwipeBack) return
+      if (screenHelmetProps.preventBackSwipe) return
 
       document.activeElement?.['blur']?.()
       x0 = x = e.touches[0].clientX
@@ -117,7 +117,7 @@ const Card: React.FC<ICardProps> = (props) => {
     edgeRef,
     setPopped,
     pop,
-    screenHelmetProps.preventSwipeBack,
+    screenHelmetProps.preventBackSwipe,
   ])
 
   const onTopClick = useCallback(() => {

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -65,6 +65,8 @@ const Card: React.FC<ICardProps> = (props) => {
     })
 
     const onTouchStart = (e: TouchEvent) => {
+      if (screenHelmetProps.preventSwipeBack) return
+
       document.activeElement?.['blur']?.()
       x0 = x = e.touches[0].clientX
       t0 = Date.now()
@@ -108,7 +110,15 @@ const Card: React.FC<ICardProps> = (props) => {
       $edge.removeEventListener('touchmove', onTouchMove)
       $edge.removeEventListener('touchend', onTouchEnd)
     }
-  }, [dimRef, frameRef, frameOffsetRef, edgeRef, setPopped, pop])
+  }, [
+    dimRef,
+    frameRef,
+    frameOffsetRef,
+    edgeRef,
+    setPopped,
+    pop,
+    screenHelmetProps.preventSwipeBack,
+  ])
 
   const onTopClick = useCallback(() => {
     const $frame = frameRef.current

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -126,6 +126,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
 
   return (
     <div
+      data-testid="nav-bar"
       className={css.container({
         cupertinoAndIsNotPresent:
           cupertino && !props.isPresent ? true : undefined,

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -126,7 +126,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
 
   return (
     <div
-      data-testid="nav-bar"
+      data-testid="navbar"
       className={css.container({
         cupertinoAndIsNotPresent:
           cupertino && !props.isPresent ? true : undefined,

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -20,7 +20,7 @@ export function makeScreenHelmetDefaultProps(): IScreenHelmetProps {
     disableScrollToTop: false,
     noBorder: false,
     onTopClick: undefined,
-    preventSwipeBack: false,
+    preventBackSwipe: false,
   }
 }
 

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -20,6 +20,7 @@ export function makeScreenHelmetDefaultProps(): IScreenHelmetProps {
     disableScrollToTop: false,
     noBorder: false,
     onTopClick: undefined,
+    preventSwipeBack: false,
   }
 }
 

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -20,7 +20,7 @@ export function makeScreenHelmetDefaultProps(): IScreenHelmetProps {
     disableScrollToTop: false,
     noBorder: false,
     onTopClick: undefined,
-    preventBackSwipe: false,
+    preventSwipeBack: false,
   }
 }
 


### PR DESCRIPTION
## `visible`

- add `visible` option into `ScreenHelmet` to control visibility for navbar
- `visible` option is passed `setScreenHelmetVisible` of `ScreenHelmet` when `ScreenHelmet` is mounted

## `preventBackSwipe`

- add `preventBackSwipe` option into `ScreenHelmet` to block swipe back action with `true` value
- `preventBackSwipe` is passed into dependencies of useEffect from `Card` because it should re-render to initialize `$edge` by `preventBackSwipe`