### PR TITLE
feat: Support hook when navbar is mounted and unmounted

### DIFF
--- a/packages/navigator-plugin/src/types/navigator.ts
+++ b/packages/navigator-plugin/src/types/navigator.ts
@@ -14,6 +14,75 @@ interface IScreenInstance {
   as: string
 }
 
+export interface IScreenHelmetProps {
+  /**
+   * title
+   */
+  title?: React.ReactNode
+
+  /**
+   * Append elements in left side
+   * (It'll be displayed in right side of back button)
+   */
+  appendLeft?: React.ReactNode
+
+  /**
+   * Append elements in right side
+   * (It'll be displayed in left side of close button when `closeButtonLocation` is `right`)
+   */
+  appendRight?: React.ReactNode
+
+  /**
+   * Location of close button (default: `left`)
+   */
+  closeButtonLocation?: 'left' | 'right'
+
+  /**
+   * Replace back button
+   */
+  customBackButton?: React.ReactNode
+
+  /**
+   * Replace close button
+   */
+  customCloseButton?: React.ReactNode
+
+  /**
+   * Remove border
+   */
+  noBorder?: boolean
+
+  /**
+   * Disable scroll to top feature (iOS Only)
+   */
+  disableScrollToTop?: boolean
+
+  /**
+   * When top part clicked (iOS Only)
+   */
+  onTopClick?: () => void
+
+  /**
+   * Set visibility for NavBar (default: `true`)
+   */
+  visible?: boolean
+
+  /**
+   * block event when users try to swipe back
+   */
+  preventSwipeBack?: boolean
+
+  /**
+   * hide back button from navbar in ScreenHelmet
+   */
+  noBackButton?: boolean
+
+  /**
+   * hide close button from navbar in ScreenHelmet
+   */
+  noCloseButton?: boolean
+}
+
 interface Options {
   pop?: (from: string) => void
   push?: (to: string) => void
@@ -108,6 +177,14 @@ export interface OnAddScreenInstancePromise extends HookParams {
   }
 }
 
+export interface OnMountNavbar extends HookParams {
+  screenHelmetProps: IScreenHelmetProps
+}
+
+export interface OnUnmountNavbar extends HookParams {
+  screenHelmetProps: IScreenHelmetProps
+}
+
 export interface PluginType {
   lifeCycleHooks: {
     beforePush?: (
@@ -170,6 +247,14 @@ export interface PluginType {
       context: OnAddScreenInstancePromise,
       next: (newCtx?: any) => Promise<OnAddScreenInstancePromise | void>
     ) => Promise<OnAddScreenInstancePromise | void>
+    onMountNavbar?: (
+      context: OnMountNavbar,
+      next: (newCtx?: any) => Promise<OnMountNavbar | void>
+    ) => Promise<OnAddScreenInstancePromise | void>
+    onUnmountNavbar?: (
+      context: OnUnmountNavbar,
+      next: (newCtx?: any) => Promise<OnUnmountNavbar | void>
+    ) => Promise<OnUnmountNavbar | void>
   }
 }
 export type NavigatorPluginType = {

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 
@@ -8,6 +8,7 @@ import { INavigatorTheme } from '../types'
 import { useNavigator } from '../useNavigator'
 import * as css from './Navbar.css'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
+import { usePlugins } from '../globalState/Plugins'
 
 interface INavbarProps {
   screenInstanceId: string
@@ -125,6 +126,33 @@ const Navbar: React.FC<INavbarProps> = (props) => {
   )
 
   const noBorder = screenHelmetProps.noBorder
+
+  const { lifecycleHooks } = usePlugins()
+
+  const onMountNavbar = useCallback(() => {
+    lifecycleHooks.forEach((hook) => {
+      const context = {
+        screenHelmetProps,
+      } as any
+      hook?.onMountNavbar?.(context)
+    })
+  }, [lifecycleHooks, screenHelmetProps])
+
+  const onUnmountNavbar = useCallback(() => {
+    lifecycleHooks.forEach((hook) => {
+      const context = {
+        screenHelmetProps,
+      } as any
+      hook?.onUnmountNavbar?.(context)
+    })
+  }, [lifecycleHooks, screenHelmetProps])
+
+  useEffect(() => {
+    onMountNavbar()
+    return () => {
+      onUnmountNavbar()
+    }
+  }, [onMountNavbar, onUnmountNavbar])
 
   return (
     <div


### PR DESCRIPTION
- expose hook to access ScreenHelmetProps when navbar is mounted and is unmounted
- ScreenHelmet is used to control metadata, but ScreenHelmet do also control navbar component. IMHO, mounting navbar is a point for plugin hook.
  - But `beforeMountNavbar` is not supported yet. It should be discussed to check whether this hook is required and how to implement that. 