### PR TITLE
fix(navigator): Declare children props explicitly [skip ci]

### DIFF
--- a/packages/navigator/src/Navigator.tsx
+++ b/packages/navigator/src/Navigator.tsx
@@ -69,6 +69,11 @@ interface INavigatorProps {
    * external plugins to apply to navigator
    */
   plugins?: NavigatorPluginType[]
+
+  /**
+   * children components
+   */
+  children?: React.ReactNode
 }
 const Navigator: React.FC<INavigatorProps> = ({
   theme = 'Android',

--- a/packages/navigator/src/Screen.tsx
+++ b/packages/navigator/src/Screen.tsx
@@ -12,6 +12,11 @@ interface IScreenProps {
    * Component
    */
   component?: React.ComponentType
+
+  /**
+   * children components
+   */
+  children?: React.ReactNode
 }
 const Screen: React.FC<IScreenProps> = (props) => {
   const { path } = props


### PR DESCRIPTION
- 'children' basic prop is removed in @types of React 18