### PR TITLE
Feat/navbar transition

### DIFF
--- a/packages/navigator/src/Navigator.css.ts
+++ b/packages/navigator/src/Navigator.css.ts
@@ -14,6 +14,8 @@ const vars = createGlobalThemeContract(
         textColor: null,
         mainWidth: null,
       },
+      animationDuration: '',
+      translateY: null,
     },
     animationDuration: '',
   },
@@ -32,6 +34,8 @@ const Android = createTheme(vars, {
       textColor: '#212529',
       mainWidth: '',
     },
+    animationDuration: '',
+    translateY: '0',
   },
   animationDuration: '',
 })
@@ -48,6 +52,8 @@ const Cupertino = createTheme(vars, {
       textColor: '#212529',
       mainWidth: '',
     },
+    animationDuration: '',
+    translateY: '0',
   },
   animationDuration: '',
 })

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -102,6 +102,7 @@ export const main = recipe({
     width: '100%',
     height: '100%',
     boxSizing: 'border-box',
+    transition: `padding-top ${vars.navbar.animationDuration} ease-in-out`,
   },
   variants: {
     cupertinoAndIsPresent: {

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -146,7 +146,7 @@ const Card: React.FC<ICardProps> = (props) => {
       return '0.3s'
     }
 
-    return '0.12s'
+    return '0.3s'
   }, [isNavbarVisible])
 
   return (

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -146,7 +146,7 @@ const Card: React.FC<ICardProps> = (props) => {
       return '0.3s'
     }
 
-    return '0.2s'
+    return '0.12s'
   }, [isNavbarVisible])
 
   return (

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -146,7 +146,7 @@ const Card: React.FC<ICardProps> = (props) => {
       return '0.3s'
     }
 
-    return '0.25s'
+    return '0.2s'
   }, [isNavbarVisible])
 
   return (

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { INavigatorTheme } from '../types'
 import { useNavigator } from '../useNavigator'

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -7,6 +7,9 @@ import { makeTranslation } from './Card.translation'
 import Navbar from './Navbar'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
 import { useAnimationContext } from '../globalState/Animation'
+import { useMounted } from '../hooks'
+import { assignInlineVars } from '@vanilla-extract/dynamic'
+import { vars } from '../Navigator.css'
 
 interface ICardProps {
   theme: INavigatorTheme
@@ -24,6 +27,7 @@ interface ICardProps {
   onClose: () => void
 }
 const Card: React.FC<ICardProps> = (props) => {
+  const mounted = useMounted()
   const { shouldAnimate } = useAnimationContext()
 
   const { pop } = useNavigator()
@@ -170,19 +174,21 @@ const Card: React.FC<ICardProps> = (props) => {
             cupertinoAndIsPresent:
               cupertino && props.isPresent ? true : undefined,
           })}
+          style={assignInlineVars({
+            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+          })}
         >
-          {isNavbarVisible && (
-            <Navbar
-              screenInstanceId={props.screenInstanceId}
-              theme={props.theme}
-              isRoot={props.isRoot}
-              isPresent={props.isPresent}
-              backButtonAriaLabel={props.backButtonAriaLabel}
-              closeButtonAriaLabel={props.closeButtonAriaLabel}
-              onClose={props.onClose}
-              onTopClick={onTopClick}
-            />
-          )}
+          <Navbar
+            isNavbarVisible={isNavbarVisible}
+            screenInstanceId={props.screenInstanceId}
+            theme={props.theme}
+            isRoot={props.isRoot}
+            isPresent={props.isPresent}
+            backButtonAriaLabel={props.backButtonAriaLabel}
+            closeButtonAriaLabel={props.closeButtonAriaLabel}
+            onClose={props.onClose}
+            onTopClick={onTopClick}
+          />
           <div
             className={css.frameOffset({
               noAnimate: !shouldAnimate ? true : undefined,

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -137,18 +137,6 @@ const Card: React.FC<ICardProps> = (props) => {
 
   const isNavbarVisible = screenHelmetVisible ?? false
 
-  const animationDuration = useMemo(() => {
-    if (!mounted) {
-      return '0'
-    }
-
-    if (isNavbarVisible) {
-      return '0.3s'
-    }
-
-    return '0.3s'
-  }, [isNavbarVisible])
-
   return (
     <div ref={props.nodeRef} className={css.container}>
       {!props.isRoot && (
@@ -187,7 +175,7 @@ const Card: React.FC<ICardProps> = (props) => {
               cupertino && props.isPresent ? true : undefined,
           })}
           style={assignInlineVars({
-            [vars.navbar.animationDuration]: animationDuration,
+            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
           })}
         >
           <Navbar

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { INavigatorTheme } from '../types'
 import { useNavigator } from '../useNavigator'
@@ -137,6 +137,18 @@ const Card: React.FC<ICardProps> = (props) => {
 
   const isNavbarVisible = screenHelmetVisible ?? false
 
+  const animationDuration = useMemo(() => {
+    if (!mounted) {
+      return '0'
+    }
+
+    if (isNavbarVisible) {
+      return '0.3s'
+    }
+
+    return '0.25s'
+  }, [isNavbarVisible])
+
   return (
     <div ref={props.nodeRef} className={css.container}>
       {!props.isRoot && (
@@ -175,7 +187,7 @@ const Card: React.FC<ICardProps> = (props) => {
               cupertino && props.isPresent ? true : undefined,
           })}
           style={assignInlineVars({
-            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+            [vars.navbar.animationDuration]: animationDuration,
           })}
         >
           <Navbar

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { INavigatorTheme } from '../types'
 import { useNavigator } from '../useNavigator'
@@ -137,6 +137,18 @@ const Card: React.FC<ICardProps> = (props) => {
 
   const isNavbarVisible = screenHelmetVisible ?? false
 
+  const animationDuration = useMemo(() => {
+    if (!mounted) {
+      return '0'
+    }
+
+    if (isNavbarVisible) {
+      return '0.3s'
+    }
+
+    return '0.3s'
+  }, [isNavbarVisible])
+
   return (
     <div ref={props.nodeRef} className={css.container}>
       {!props.isRoot && (
@@ -175,7 +187,7 @@ const Card: React.FC<ICardProps> = (props) => {
               cupertino && props.isPresent ? true : undefined,
           })}
           style={assignInlineVars({
-            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+            [vars.navbar.animationDuration]: animationDuration,
           })}
         >
           <Navbar

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -143,10 +143,10 @@ const Card: React.FC<ICardProps> = (props) => {
     }
 
     if (isNavbarVisible) {
-      return '0.3s'
+      return '0.4s'
     }
 
-    return '0.3s'
+    return '0.25s'
   }, [isNavbarVisible])
 
   return (

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -18,6 +18,7 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
     ],
     backgroundColor: vars.backgroundColor,
+    opacity: 0,
     transform: `translateY(${vars.navbar.translateY})`,
     transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -17,7 +17,7 @@ export const container = recipe({
       'constant(safe-area-inset-top) 0 0',
       'env(safe-area-inset-top) 0 0',
     ],
-    backgroundColor: '#fff',
+    backgroundColor: vars.backgroundColor,
     transform: `translateY(${vars.navbar.translateY})`,
     transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -17,7 +17,7 @@ export const container = recipe({
       'constant(safe-area-inset-top) 0 0',
       'env(safe-area-inset-top) 0 0',
     ],
-    backgroundColor: vars.backgroundColor,
+    backgroundColor: '#fff',
     transform: `translateY(${vars.navbar.translateY})`,
     transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -18,7 +18,6 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
     ],
     backgroundColor: vars.backgroundColor,
-    opacity: 0,
     transform: `translateY(${vars.navbar.translateY})`,
     transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -18,6 +18,8 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
     ],
     backgroundColor: vars.backgroundColor,
+    transform: `translateY(${vars.navbar.translateY})`,
+    transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },
   variants: {
     cupertinoAndIsNotPresent: {

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -9,8 +9,10 @@ import { useNavigator } from '../useNavigator'
 import * as css from './Navbar.css'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
 import { usePlugins } from '../globalState/Plugins'
+import { useMounted } from '../hooks'
 
 interface INavbarProps {
+  isNavbarVisible: boolean
   screenInstanceId: string
   theme: INavigatorTheme
   isRoot: boolean
@@ -21,6 +23,8 @@ interface INavbarProps {
   onClose: () => void
 }
 const Navbar: React.FC<INavbarProps> = (props) => {
+  const mounted = useMounted()
+
   const { pop } = useNavigator()
   const { screenHelmetProps } = useScreenHelmet()
 
@@ -164,6 +168,8 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       ref={navbarRef}
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
+        [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-40px',
       })}
     >
       <div

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -169,7 +169,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
         [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
-        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-40px',
+        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-2.75rem',
       })}
     >
       <div

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -164,7 +164,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
     }
 
     if (props.isNavbarVisible) {
-      return '0.25s'
+      return '0.35s'
     }
 
     return '0.4s'

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -168,7 +168,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       ref={navbarRef}
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
-        [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+        [vars.navbar.animationDuration]: mounted ? '0.4s' : '0',
         [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-2.75rem',
       })}
     >

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 
@@ -158,6 +158,18 @@ const Navbar: React.FC<INavbarProps> = (props) => {
     }
   }, [onMountNavbar, onUnmountNavbar])
 
+  const animationDuration = useMemo(() => {
+    if (!mounted) {
+      return '0'
+    }
+
+    if (props.isNavbarVisible) {
+      return '0.25s'
+    }
+
+    return '0.4s'
+  }, [props.isNavbarVisible])
+
   return (
     <div
       data-testid="navbar"
@@ -168,7 +180,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       ref={navbarRef}
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
-        [vars.navbar.animationDuration]: mounted ? '0.4s' : '0',
+        [vars.navbar.animationDuration]: animationDuration,
         [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-2.75rem',
       })}
     >

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -35,7 +35,7 @@ const ContextScreenHelmet = createContext<{
 }>(null as any)
 
 export const ProviderScreenHelmet: React.FC = (props) => {
-  const [screenHelmetVisible, setScreenHelmetVisible] = useState(false)
+  const [screenHelmetVisible, setScreenHelmetVisible] = useState(true)
   const [screenHelmetProps, setScreenHelmetProps] =
     useDeepState<IScreenHelmetProps>(makeScreenHelmetDefaultProps())
 

--- a/packages/navigator/src/helpers/nextTick.ts
+++ b/packages/navigator/src/helpers/nextTick.ts
@@ -1,3 +1,3 @@
 export function nextTick(callback: () => void) {
-  return Promise.resolve().then(callback)
+  setTimeout(callback, 0)
 }

--- a/packages/navigator/src/hooks/index.ts
+++ b/packages/navigator/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDeepState'
 export * from './useHistoryEffect'
 export * from './useIncrementalId'
+export * from './useMounted'

--- a/packages/navigator/src/hooks/useMounted.ts
+++ b/packages/navigator/src/hooks/useMounted.ts
@@ -1,0 +1,11 @@
+import { useEffect, useReducer } from 'react'
+import { nextTick } from '../helpers'
+
+export function useMounted() {
+  const [mounted, mount] = useReducer(() => true, false)
+  useEffect(() => {
+    nextTick(() => mount())
+  }, [mount])
+
+  return mounted
+}


### PR DESCRIPTION
- `visible` false 일 때 기존에는 컴포넌트를 언마운트했는데, 이제는 translateY 로 viewport 바깥으로 밀어내요. 무거운 컴포넌트가 아니기 때문에 언마운트가 아니어도 성능에 큰 차이가 없을거라고 생각해요.

- `nextTick` helper 함수 내부에서 setTimeout 을 사용해요. 기존에는 `Promise.resolve` 를 사용했어요.

- vanilla-extract 의 `assignInlineVars` 를 사용해서 vars.navbar.animationDuration 과 vars.navbar.translateY 를 다루어요.

    - variant 를 추가하는 것이 더 복잡도를 늘린다고 판단하여 assignInlineVars 을 사용하기로 결정했어요
    
    -  추후 animationDuration 을 option 으로 받아 동적으로 다룰 경우 수정이 용이해요

    - 전체 코드에서 assignInlineVars 사용빈도가 아주 적기 때문에 사용을 지양하는 convention 이 따로 있거나, 스타일링 규칙을 따르지 않은 것이 아닐까 우려가 있어요.

- vars.navbar.animationDuration 는 mounted 가 true 일 때 0 이외의 값을 가져요

- vars.navbar.translateY 는 isNavbarVisible 이 true 일 때 0 이고 false 일 때 -2.75rem 이에요.