### PR TITLE
feat(navigator): navbar transition

### DIFF
--- a/packages/navigator/src/Navigator.css.ts
+++ b/packages/navigator/src/Navigator.css.ts
@@ -14,6 +14,8 @@ const vars = createGlobalThemeContract(
         textColor: null,
         mainWidth: null,
       },
+      animationDuration: '',
+      translateY: null,
     },
     animationDuration: '',
   },
@@ -32,6 +34,8 @@ const Android = createTheme(vars, {
       textColor: '#212529',
       mainWidth: '',
     },
+    animationDuration: '',
+    translateY: '0',
   },
   animationDuration: '',
 })
@@ -48,6 +52,8 @@ const Cupertino = createTheme(vars, {
       textColor: '#212529',
       mainWidth: '',
     },
+    animationDuration: '',
+    translateY: '0',
   },
   animationDuration: '',
 })

--- a/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
+++ b/packages/navigator/src/__tests__/ScreenHelmet.test.tsx
@@ -33,15 +33,13 @@ describe('ScreenHelmet - visible: ', () => {
   }
 
   it('visible: false 이면 navbar 가 나타나지 않는다', () => {
-    const { queryByTestId } = renderScreenHelmet({ visible: false })
-    const navBar = queryByTestId('navbar')
-    expect(navBar).not.toBeInTheDocument()
+    const { asFragment } = renderScreenHelmet({ visible: false })
+    expect(asFragment()).toMatchSnapshot()
   })
 
   it('visible: true 이면 navbar 가 나타난다', () => {
-    const { getByTestId } = renderScreenHelmet({ visible: true })
-    const navBar = getByTestId('navbar')
-    expect(navBar).toBeVisible()
+    const { asFragment } = renderScreenHelmet({ visible: true })
+    expect(asFragment()).toMatchSnapshot()
   })
 })
 

--- a/packages/navigator/src/__tests__/__snapshots__/ScreenHelmet.test.tsx.snap
+++ b/packages/navigator/src/__tests__/__snapshots__/ScreenHelmet.test.tsx.snap
@@ -1,0 +1,181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScreenHelmet - visible:  visible: false 이면 navbar 가 나타나지 않는다 1`] = `
+<DocumentFragment>
+  <div
+    class="Navigator_root__hije1d2 Navigator_root_Android__hije1d3 Navigator_Android__hije1d0"
+    style="--kf_navigator_animationDuration: 270ms;"
+  >
+    <div
+      class="Card_container__1ok9rul0 Card_container_enterActive__1ok9rul1"
+    >
+      <div
+        class="Card_mainOffset__1ok9rul9"
+      >
+        <div
+          class="Card_main__1ok9rulc Card_main_true__1ok9rulh Card_main_true__1ok9rulj Card_main_true__1ok9rulk"
+          style="--kf_navigator_navbar-animationDuration: 0;"
+        >
+          <div
+            class="Navbar_container__x613ng0"
+            data-testid="navbar"
+            style="--kf_navigator_navbar-center-mainWidth: undefinedpx; --kf_navigator_navbar-animationDuration: 0; --kf_navigator_navbar-translateY: -2.75rem;"
+          >
+            <div
+              class="Navbar_main__x613ng2"
+            >
+              <div
+                class="Navbar_flex__x613ng4"
+              >
+                <div
+                  class="Navbar_left__x613ng5"
+                >
+                  <a
+                    aria-label="Close"
+                    class="Navbar_closeButton__x613ng9"
+                    role="text"
+                  >
+                    <svg
+                      class="Navbar_svgIcon__x613ngj"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6.56588 5.43433C6.25346 5.12191 5.74693 5.12191 5.43451 5.43433C5.12209 5.74675 5.12209 6.25328 5.43451 6.5657L10.8688 12L5.43451 17.4343C5.12209 17.7467 5.12209 18.2533 5.43451 18.5657C5.74693 18.8781 6.25346 18.8781 6.56588 18.5657L12.0002 13.1314L17.4345 18.5657C17.7469 18.8781 18.2535 18.8781 18.5659 18.5657C18.8783 18.2533 18.8783 17.7467 18.5659 17.4343L13.1316 12L18.5659 6.5657C18.8783 6.25328 18.8783 5.74675 18.5659 5.43433C18.2535 5.12191 17.7469 5.12191 17.4345 5.43433L12.0002 10.8686L6.56588 5.43433Z"
+                        fill="currentColor"
+                      />
+                      <path
+                        d="M6.56588 5.43433C6.25346 5.12191 5.74693 5.12191 5.43451 5.43433C5.12209 5.74675 5.12209 6.25328 5.43451 6.5657L10.8688 12L5.43451 17.4343C5.12209 17.7467 5.12209 18.2533 5.43451 18.5657C5.74693 18.8781 6.25346 18.8781 6.56588 18.5657L12.0002 13.1314L17.4345 18.5657C17.7469 18.8781 18.2535 18.8781 18.5659 18.5657C18.8783 18.2533 18.8783 17.7467 18.5659 17.4343L13.1316 12L18.5659 6.5657C18.8783 6.25328 18.8783 5.74675 18.5659 5.43433C18.2535 5.12191 17.7469 5.12191 17.4345 5.43433L12.0002 10.8686L6.56588 5.43433Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </a>
+                </div>
+                <div
+                  class="Navbar_center__x613nga Navbar_center_true__x613ngb"
+                >
+                  <div
+                    class="Navbar_centerMain__x613ngc Navbar_centerMain_true__x613ngd Navbar_centerMain_true__x613nge"
+                  />
+                  <div
+                    class="Navbar_centerMainEdge__x613ngh"
+                  />
+                </div>
+                <div
+                  class="Navbar_right__x613ng7 Navbar_right_true__x613ng8"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="Card_frameOffset__1ok9rull"
+          >
+            <div
+              class="Card_frame__1ok9rulp"
+            >
+              <div>
+                <span>
+                  example
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScreenHelmet - visible:  visible: true 이면 navbar 가 나타난다 1`] = `
+<DocumentFragment>
+  <div
+    class="Navigator_root__hije1d2 Navigator_root_Android__hije1d3 Navigator_Android__hije1d0"
+    style="--kf_navigator_animationDuration: 270ms;"
+  >
+    <div
+      class="Card_container__1ok9rul0 Card_container_enterActive__1ok9rul1"
+    >
+      <div
+        class="Card_mainOffset__1ok9rul9"
+      >
+        <div
+          class="Card_main__1ok9rulc Card_main_true__1ok9rulh Card_main_true__1ok9ruli Card_main_true__1ok9rulj"
+          style="--kf_navigator_navbar-animationDuration: 0;"
+        >
+          <div
+            class="Navbar_container__x613ng0"
+            data-testid="navbar"
+            style="--kf_navigator_navbar-center-mainWidth: undefinedpx; --kf_navigator_navbar-animationDuration: 0; --kf_navigator_navbar-translateY: 0;"
+          >
+            <div
+              class="Navbar_main__x613ng2"
+            >
+              <div
+                class="Navbar_flex__x613ng4"
+              >
+                <div
+                  class="Navbar_left__x613ng5"
+                >
+                  <a
+                    aria-label="Close"
+                    class="Navbar_closeButton__x613ng9"
+                    role="text"
+                  >
+                    <svg
+                      class="Navbar_svgIcon__x613ngj"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6.56588 5.43433C6.25346 5.12191 5.74693 5.12191 5.43451 5.43433C5.12209 5.74675 5.12209 6.25328 5.43451 6.5657L10.8688 12L5.43451 17.4343C5.12209 17.7467 5.12209 18.2533 5.43451 18.5657C5.74693 18.8781 6.25346 18.8781 6.56588 18.5657L12.0002 13.1314L17.4345 18.5657C17.7469 18.8781 18.2535 18.8781 18.5659 18.5657C18.8783 18.2533 18.8783 17.7467 18.5659 17.4343L13.1316 12L18.5659 6.5657C18.8783 6.25328 18.8783 5.74675 18.5659 5.43433C18.2535 5.12191 17.7469 5.12191 17.4345 5.43433L12.0002 10.8686L6.56588 5.43433Z"
+                        fill="currentColor"
+                      />
+                      <path
+                        d="M6.56588 5.43433C6.25346 5.12191 5.74693 5.12191 5.43451 5.43433C5.12209 5.74675 5.12209 6.25328 5.43451 6.5657L10.8688 12L5.43451 17.4343C5.12209 17.7467 5.12209 18.2533 5.43451 18.5657C5.74693 18.8781 6.25346 18.8781 6.56588 18.5657L12.0002 13.1314L17.4345 18.5657C17.7469 18.8781 18.2535 18.8781 18.5659 18.5657C18.8783 18.2533 18.8783 17.7467 18.5659 17.4343L13.1316 12L18.5659 6.5657C18.8783 6.25328 18.8783 5.74675 18.5659 5.43433C18.2535 5.12191 17.7469 5.12191 17.4345 5.43433L12.0002 10.8686L6.56588 5.43433Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </a>
+                </div>
+                <div
+                  class="Navbar_center__x613nga Navbar_center_true__x613ngb"
+                >
+                  <div
+                    class="Navbar_centerMain__x613ngc Navbar_centerMain_true__x613ngd Navbar_centerMain_true__x613nge"
+                  />
+                  <div
+                    class="Navbar_centerMainEdge__x613ngh"
+                  />
+                </div>
+                <div
+                  class="Navbar_right__x613ng7 Navbar_right_true__x613ng8"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="Card_frameOffset__1ok9rull"
+          >
+            <div
+              class="Card_frame__1ok9rulp"
+            >
+              <div>
+                <span>
+                  example
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -185,6 +185,11 @@ export const main = recipe({
         transform: 'translateY(0)',
       },
     },
+    isTopAndIsNoNavbarVisible: {
+      true: {
+        backgroundColor: '#fff',
+      },
+    },
   },
 })
 

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -102,6 +102,7 @@ export const main = recipe({
     width: '100%',
     height: '100%',
     boxSizing: 'border-box',
+    transition: `padding-top ${vars.navbar.animationDuration} ease-in-out`,
   },
   variants: {
     cupertinoAndIsPresent: {

--- a/packages/navigator/src/components/Card.css.ts
+++ b/packages/navigator/src/components/Card.css.ts
@@ -185,7 +185,7 @@ export const main = recipe({
         transform: 'translateY(0)',
       },
     },
-    isTopAndIsNoNavbarVisible: {
+    isTopAndIsNavbarNotVisible: {
       true: {
         backgroundColor: '#fff',
       },

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -27,7 +27,7 @@ interface ICardProps {
   onClose: () => void
 }
 const Card: React.FC<ICardProps> = (props) => {
-  const mounted = useMounted()
+  const mounted = useMounted({ afterTick: true })
   const { shouldAnimate } = useAnimationContext()
 
   const { pop } = useNavigator()

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -173,6 +173,8 @@ const Card: React.FC<ICardProps> = (props) => {
               cupertino && isNavbarVisible ? true : undefined,
             cupertinoAndIsPresent:
               cupertino && props.isPresent ? true : undefined,
+            isTopAndIsNoNavbarVisible:
+              props.isTop && !isNavbarVisible ? true : undefined,
           })}
           style={assignInlineVars({
             [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -7,6 +7,9 @@ import { makeTranslation } from './Card.translation'
 import Navbar from './Navbar'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
 import { useAnimationContext } from '../globalState/Animation'
+import { useMounted } from '../hooks'
+import { assignInlineVars } from '@vanilla-extract/dynamic'
+import { vars } from '../Navigator.css'
 
 interface ICardProps {
   theme: INavigatorTheme
@@ -24,6 +27,7 @@ interface ICardProps {
   onClose: () => void
 }
 const Card: React.FC<ICardProps> = (props) => {
+  const mounted = useMounted()
   const { shouldAnimate } = useAnimationContext()
 
   const { pop } = useNavigator()
@@ -170,19 +174,21 @@ const Card: React.FC<ICardProps> = (props) => {
             cupertinoAndIsPresent:
               cupertino && props.isPresent ? true : undefined,
           })}
+          style={assignInlineVars({
+            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+          })}
         >
-          {isNavbarVisible && (
-            <Navbar
-              screenInstanceId={props.screenInstanceId}
-              theme={props.theme}
-              isRoot={props.isRoot}
-              isPresent={props.isPresent}
-              backButtonAriaLabel={props.backButtonAriaLabel}
-              closeButtonAriaLabel={props.closeButtonAriaLabel}
-              onClose={props.onClose}
-              onTopClick={onTopClick}
-            />
-          )}
+          <Navbar
+            isNavbarVisible={isNavbarVisible}
+            screenInstanceId={props.screenInstanceId}
+            theme={props.theme}
+            isRoot={props.isRoot}
+            isPresent={props.isPresent}
+            backButtonAriaLabel={props.backButtonAriaLabel}
+            closeButtonAriaLabel={props.closeButtonAriaLabel}
+            onClose={props.onClose}
+            onTopClick={onTopClick}
+          />
           <div
             className={css.frameOffset({
               noAnimate: !shouldAnimate ? true : undefined,

--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -173,7 +173,7 @@ const Card: React.FC<ICardProps> = (props) => {
               cupertino && isNavbarVisible ? true : undefined,
             cupertinoAndIsPresent:
               cupertino && props.isPresent ? true : undefined,
-            isTopAndIsNoNavbarVisible:
+            isTopAndIsNavbarNotVisible:
               props.isTop && !isNavbarVisible ? true : undefined,
           })}
           style={assignInlineVars({

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -18,6 +18,8 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
     ],
     backgroundColor: vars.backgroundColor,
+    transform: `translateY(${vars.navbar.translateY})`,
+    transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },
   variants: {
     cupertinoAndIsNotPresent: {

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -9,8 +9,10 @@ import { useNavigator } from '../useNavigator'
 import * as css from './Navbar.css'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
 import { usePlugins } from '../globalState/Plugins'
+import { useMounted } from '../hooks'
 
 interface INavbarProps {
+  isNavbarVisible: boolean
   screenInstanceId: string
   theme: INavigatorTheme
   isRoot: boolean
@@ -21,6 +23,8 @@ interface INavbarProps {
   onClose: () => void
 }
 const Navbar: React.FC<INavbarProps> = (props) => {
+  const mounted = useMounted()
+
   const { pop } = useNavigator()
   const { screenHelmetProps } = useScreenHelmet()
 
@@ -164,6 +168,8 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       ref={navbarRef}
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
+        [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-40px',
       })}
     >
       <div

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -169,7 +169,7 @@ const Navbar: React.FC<INavbarProps> = (props) => {
       style={assignInlineVars({
         [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
         [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
-        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-40px',
+        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : '-2.75rem',
       })}
     >
       <div

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -23,7 +23,7 @@ interface INavbarProps {
   onClose: () => void
 }
 const Navbar: React.FC<INavbarProps> = (props) => {
-  const mounted = useMounted()
+  const mounted = useMounted({ afterTick: true })
 
   const { pop } = useNavigator()
   const { screenHelmetProps } = useScreenHelmet()

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -35,7 +35,7 @@ const ContextScreenHelmet = createContext<{
 }>(null as any)
 
 export const ProviderScreenHelmet: React.FC = (props) => {
-  const [screenHelmetVisible, setScreenHelmetVisible] = useState(false)
+  const [screenHelmetVisible, setScreenHelmetVisible] = useState(true)
   const [screenHelmetProps, setScreenHelmetProps] =
     useDeepState<IScreenHelmetProps>(makeScreenHelmetDefaultProps())
 

--- a/packages/navigator/src/helpers/nextTick.ts
+++ b/packages/navigator/src/helpers/nextTick.ts
@@ -1,3 +1,3 @@
 export function nextTick(callback: () => void) {
-  return Promise.resolve().then(callback)
+  setTimeout(callback, 0)
 }

--- a/packages/navigator/src/hooks/index.ts
+++ b/packages/navigator/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDeepState'
 export * from './useHistoryEffect'
 export * from './useIncrementalId'
+export * from './useMounted'

--- a/packages/navigator/src/hooks/useMounted.ts
+++ b/packages/navigator/src/hooks/useMounted.ts
@@ -3,6 +3,7 @@ import { nextTick } from '../helpers'
 
 export function useMounted() {
   const [mounted, mount] = useReducer(() => true, false)
+
   useEffect(() => {
     nextTick(() => mount())
   }, [mount])

--- a/packages/navigator/src/hooks/useMounted.ts
+++ b/packages/navigator/src/hooks/useMounted.ts
@@ -1,12 +1,21 @@
 import { useEffect, useReducer } from 'react'
 import { nextTick } from '../helpers'
 
-export function useMounted() {
+interface Options {
+  afterTick?: boolean
+}
+
+export function useMounted(options?: Options) {
   const [mounted, mount] = useReducer(() => true, false)
 
   useEffect(() => {
-    nextTick(() => mount())
-  }, [mount])
+    if (options?.afterTick) {
+      nextTick(() => mount())
+      return
+    }
+
+    mount()
+  }, [mount, options])
 
   return mounted
 }

--- a/packages/navigator/src/hooks/useMounted.ts
+++ b/packages/navigator/src/hooks/useMounted.ts
@@ -1,0 +1,11 @@
+import { useEffect, useReducer } from 'react'
+import { nextTick } from '../helpers'
+
+export function useMounted() {
+  const [mounted, mount] = useReducer(() => true, false)
+  useEffect(() => {
+    nextTick(() => mount())
+  }, [mount])
+
+  return mounted
+}


### PR DESCRIPTION
https://user-images.githubusercontent.com/10165823/165315197-2408ff50-f665-4688-9351-4080056b8b82.MP4

- visible false 일 때 기존에는 컴포넌트를 언마운트했는데, 이제는 translateY 로 viewport 바깥으로 밀어내요. 무거운 컴포넌트가 아니기 때문에 언마운트가 아니어도 성능에 큰 차이가 없을거라고 생각해요.

- nextTick helper 함수 내부에서 setTimeout 을 사용해요. 기존에는 Promise.resolve 를 사용했어요.

- vanilla-extract 의 assignInlineVars 를 사용해서 vars.navbar.animationDuration 과 vars.navbar.translateY 를 다루어요.

  - variant 를 추가하는 것이 더 복잡도를 늘린다고 판단하여 assignInlineVars 을 사용하기로 결정했어요

  - 추후 animationDuration 을 option 으로 받아 동적으로 다룰 경우 수정이 용이해요

  - 전체 코드에서 assignInlineVars 사용빈도가 아주 적기 때문에 사용을 지양하는 convention 이 따로 있거나, 스타일링 규칙을 따르지 않은 것이 아닐까 우려가 있어요.
  
  - navbar 를 viewport 위로 밀어낼 때에는, 바로 뒤의 screen 이 나타나지 않도록 variant 를 이용해서 background 를 하얀색으로 칠해요. 

- vars.navbar.animationDuration 는 mounted 가 true 일 때 0 이외의 값을 가져요

- vars.navbar.translateY 는 isNavbarVisible 이 true 일 때 0 이고 false 일 때 -2.75rem 이에요.

- 사파리에서 컴포넌트가 mount 될 때 transition 이 발생하지 않도록 screenHelmetVisible 의 초기값을 true 로 변경했어요 [참고](https://github.com/daangn/karrotframe/pull/161#issuecomment-1109504854)

- 테스트 코드를 수정했어요. 스냅샷을 사용해서 테스트해요. 
  - 기존 테스트 코드는 테스트 대상이었던 navbar 컴포넌트가 mount / unmount 되는지 확인이 가능했어요.
  - 현재는 viewport 밖으로 밀어내면서 navbar 컴포넌트가 여전히 존재하기 때문에 navbar 컴포넌트의 존재 여부를 확인하는 방법으로 테스트가 불가능하고, translate 값을 대조하는 방식으로 테스트가 가능해요. 해당 방법은 구현을 테스트하는 것이라 테스트 유지보수성을 높여요. 하지만 테스트 작성은 더 verbose 하고 까다로워져요. 그래서 스냅샷 테스트로 대체하였어요. 스냅샷 테스트 역시 작은 변화에도 쉽게 깨지기 때문에 테스트의 유지보수성을 높이지만 테스트 작성자체는 쉽고 빠르기 때문이에요.