### PR TITLE
fix(navigator): Make navbar not expose in default and modify transition condition for navbar

### DIFF
--- a/packages/navigator/src/components/Card.tsx
+++ b/packages/navigator/src/components/Card.tsx
@@ -173,6 +173,19 @@ const Card: React.FC<ICardProps> = (props) => {
     }
   }, [mainRef])
 
+  const navbarRef = useRef<{ mounted: boolean } | null>(null)
+
+  const [activeTransition, setActiveTransition] = useState(false)
+
+  useEffect(() => {
+    if (!mounted) return
+
+    const $navbar = navbarRef.current
+    if (!$navbar) return
+
+    setActiveTransition($navbar.mounted)
+  }, [mounted])
+
   return (
     <div ref={props.nodeRef} className={css.container}>
       {!props.isRoot && (
@@ -217,10 +230,11 @@ const Card: React.FC<ICardProps> = (props) => {
                 : undefined,
           })}
           style={assignInlineVars({
-            [vars.navbar.animationDuration]: mounted ? '0.3s' : '0s',
+            [vars.navbar.animationDuration]: activeTransition ? '0.3s' : '0s',
           })}
         >
           <Navbar
+            ref={navbarRef}
             isNavbarVisible={isNavbarVisible}
             screenInstanceId={props.screenInstanceId}
             theme={props.theme}

--- a/packages/navigator/src/components/Navbar.css.ts
+++ b/packages/navigator/src/components/Navbar.css.ts
@@ -18,8 +18,6 @@ export const container = recipe({
       'env(safe-area-inset-top) 0 0',
     ],
     backgroundColor: vars.backgroundColor,
-    transform: `translateY(${vars.navbar.translateY})`,
-    transition: `transform ${vars.navbar.animationDuration} ease-in-out`,
   },
   variants: {
     cupertinoAndIsNotPresent: {
@@ -71,7 +69,6 @@ export const left = style({
   display: 'flex',
   alignItems: 'center',
   height: '100%',
-  zIndex: 1,
   ':empty': {
     display: 'none',
   },
@@ -104,7 +101,6 @@ export const right = recipe({
     height: '100%',
     marginLeft: 'auto',
     position: 'relative',
-    zIndex: 1,
     ':empty': {
       display: 'none',
     },

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 
@@ -22,209 +28,213 @@ interface INavbarProps {
   onTopClick: () => void
   onClose: () => void
 }
-const Navbar: React.FC<INavbarProps> = (props) => {
-  const mounted = useMounted({ afterTick: true })
+const Navbar = React.forwardRef<{ mounted: boolean }, INavbarProps>(
+  (props, ref) => {
+    const { pop } = useNavigator()
+    const { screenHelmetProps } = useScreenHelmet()
 
-  const { pop } = useNavigator()
-  const { screenHelmetProps } = useScreenHelmet()
+    const android = props.theme === 'Android'
+    const cupertino = props.theme === 'Cupertino'
 
-  const android = props.theme === 'Android'
-  const cupertino = props.theme === 'Cupertino'
+    const navbarHeight = android ? '-3.5rem' : '-2.75rem'
 
-  const navbarHeight = android ? '-3.5rem' : '-2.75rem'
+    const [centerMainWidth, setCenterMainWidth] = useState<number | undefined>(
+      undefined
+    )
 
-  const [centerMainWidth, setCenterMainWidth] = useState<number | undefined>(
-    undefined
-  )
+    const navbarRef = useRef<HTMLDivElement>(null)
+    const centerRef = useRef<HTMLDivElement>(null)
 
-  const navbarRef = useRef<HTMLDivElement>(null)
-  const centerRef = useRef<HTMLDivElement>(null)
+    useEffect(() => {
+      const $navbar = navbarRef.current
+      const $center = centerRef.current
 
-  useEffect(() => {
-    const $navbar = navbarRef.current
-    const $center = centerRef.current
+      const onResize = () => {
+        if (!$navbar || !$center) {
+          return
+        }
 
-    const onResize = () => {
-      if (!$navbar || !$center) {
-        return
+        const screenWidth = $navbar.clientWidth
+
+        const leftWidth = $center.offsetLeft
+        const centerWidth = $center.clientWidth
+        const rightWidth = screenWidth - leftWidth - centerWidth
+
+        const sideMargin = Math.max(leftWidth, rightWidth)
+
+        setCenterMainWidth(screenWidth - 2 * sideMargin)
       }
 
-      const screenWidth = $navbar.clientWidth
+      if (props.theme === 'Cupertino') {
+        onResize()
+        window.addEventListener('resize', onResize)
 
-      const leftWidth = $center.offsetLeft
-      const centerWidth = $center.clientWidth
-      const rightWidth = screenWidth - leftWidth - centerWidth
-
-      const sideMargin = Math.max(leftWidth, rightWidth)
-
-      setCenterMainWidth(screenWidth - 2 * sideMargin)
-    }
-
-    if (props.theme === 'Cupertino') {
-      onResize()
-      window.addEventListener('resize', onResize)
-
-      return () => {
-        window.removeEventListener('resize', onResize)
+        return () => {
+          window.removeEventListener('resize', onResize)
+        }
       }
+    }, [screenHelmetProps])
+
+    const onBackClick = () => {
+      pop()
     }
-  }, [screenHelmetProps])
 
-  const onBackClick = () => {
-    pop()
-  }
-
-  const closeButton =
-    props.onClose &&
-    props.isRoot &&
-    !screenHelmetProps.noCloseButton &&
-    (screenHelmetProps.customCloseButton ? (
-      <a
-        className={css.closeButton}
-        role="text"
-        aria-label={props.closeButtonAriaLabel}
-        onClick={props.onClose}
-      >
-        {screenHelmetProps.customCloseButton}
-      </a>
-    ) : (
-      <a
-        className={css.closeButton}
-        role="text"
-        aria-label={props.closeButtonAriaLabel}
-        onClick={props.onClose}
-      >
-        <IconClose className={css.svgIcon} />
-      </a>
-    ))
-
-  const backButton =
-    !props.isRoot &&
-    !screenHelmetProps.noBackButton &&
-    (screenHelmetProps.customBackButton ? (
-      <a
-        className={css.backButton}
-        role="text"
-        aria-label={props.backButtonAriaLabel}
-        onClick={onBackClick}
-      >
-        {screenHelmetProps.customBackButton}
-      </a>
-    ) : (
-      <a
-        className={css.backButton}
-        role="text"
-        aria-label={props.backButtonAriaLabel}
-        onClick={onBackClick}
-      >
-        {props.theme === 'Cupertino' && props.isPresent ? (
+    const closeButton =
+      props.onClose &&
+      props.isRoot &&
+      !screenHelmetProps.noCloseButton &&
+      (screenHelmetProps.customCloseButton ? (
+        <a
+          className={css.closeButton}
+          role="text"
+          aria-label={props.closeButtonAriaLabel}
+          onClick={props.onClose}
+        >
+          {screenHelmetProps.customCloseButton}
+        </a>
+      ) : (
+        <a
+          className={css.closeButton}
+          role="text"
+          aria-label={props.closeButtonAriaLabel}
+          onClick={props.onClose}
+        >
           <IconClose className={css.svgIcon} />
-        ) : (
-          <IconBack className={css.svgIcon} />
-        )}
-      </a>
-    ))
+        </a>
+      ))
 
-  const isLeft = !!(
-    (screenHelmetProps.closeButtonLocation === 'left' && closeButton) ||
-    backButton ||
-    screenHelmetProps.appendLeft
-  )
+    const backButton =
+      !props.isRoot &&
+      !screenHelmetProps.noBackButton &&
+      (screenHelmetProps.customBackButton ? (
+        <a
+          className={css.backButton}
+          role="text"
+          aria-label={props.backButtonAriaLabel}
+          onClick={onBackClick}
+        >
+          {screenHelmetProps.customBackButton}
+        </a>
+      ) : (
+        <a
+          className={css.backButton}
+          role="text"
+          aria-label={props.backButtonAriaLabel}
+          onClick={onBackClick}
+        >
+          {props.theme === 'Cupertino' && props.isPresent ? (
+            <IconClose className={css.svgIcon} />
+          ) : (
+            <IconBack className={css.svgIcon} />
+          )}
+        </a>
+      ))
 
-  const noBorder = screenHelmetProps.noBorder
+    const isLeft = !!(
+      (screenHelmetProps.closeButtonLocation === 'left' && closeButton) ||
+      backButton ||
+      screenHelmetProps.appendLeft
+    )
 
-  const { lifecycleHooks } = usePlugins()
+    const noBorder = screenHelmetProps.noBorder
 
-  const onMountNavbar = useCallback(() => {
-    lifecycleHooks.forEach((hook) => {
-      const context = {
-        screenHelmetProps,
-      } as any
-      hook?.onMountNavbar?.(context)
-    })
-  }, [lifecycleHooks, screenHelmetProps])
+    const { lifecycleHooks } = usePlugins()
 
-  const onUnmountNavbar = useCallback(() => {
-    lifecycleHooks.forEach((hook) => {
-      const context = {
-        screenHelmetProps,
-      } as any
-      hook?.onUnmountNavbar?.(context)
-    })
-  }, [lifecycleHooks, screenHelmetProps])
+    const onMountNavbar = useCallback(() => {
+      lifecycleHooks.forEach((hook) => {
+        const context = {
+          screenHelmetProps,
+        } as any
+        hook?.onMountNavbar?.(context)
+      })
+    }, [lifecycleHooks, screenHelmetProps])
 
-  useEffect(() => {
-    onMountNavbar()
-    return () => {
-      onUnmountNavbar()
-    }
-  }, [onMountNavbar, onUnmountNavbar])
+    const onUnmountNavbar = useCallback(() => {
+      lifecycleHooks.forEach((hook) => {
+        const context = {
+          screenHelmetProps,
+        } as any
+        hook?.onUnmountNavbar?.(context)
+      })
+    }, [lifecycleHooks, screenHelmetProps])
 
-  return (
-    <div
-      data-testid="navbar"
-      className={css.container({
-        cupertinoAndIsNotPresent:
-          cupertino && !props.isPresent ? true : undefined,
-      })}
-      ref={navbarRef}
-      style={assignInlineVars({
-        [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
-        [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
-        [vars.navbar.translateY]: props.isNavbarVisible ? '0' : navbarHeight,
-      })}
-    >
+    useEffect(() => {
+      onMountNavbar()
+      return () => {
+        onUnmountNavbar()
+      }
+    }, [onMountNavbar, onUnmountNavbar])
+
+    const mounted = useMounted({ afterTick: true })
+    useImperativeHandle(ref, () => ({ mounted }), [mounted])
+
+    return (
       <div
-        className={css.main({
-          noBorder: noBorder ? true : undefined,
+        data-testid="navbar"
+        className={css.container({
+          cupertinoAndIsNotPresent:
+            cupertino && !props.isPresent ? true : undefined,
+        })}
+        ref={navbarRef}
+        style={assignInlineVars({
+          [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
+          [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
+          [vars.navbar.translateY]:
+            !mounted || props.isNavbarVisible ? '0' : navbarHeight,
         })}
       >
-        <div className={css.flex}>
-          <div className={css.left}>
-            {screenHelmetProps.closeButtonLocation === 'left' && closeButton}
-            {backButton}
-            {screenHelmetProps.appendLeft}
-          </div>
-          <div
-            className={css.center({
-              android: android ? true : undefined,
-            })}
-            ref={centerRef}
-          >
-            <div
-              className={css.centerMain({
-                android: android ? true : undefined,
-                androidAndIsLeft: android && isLeft ? true : undefined,
-                cupertino: cupertino ? true : undefined,
-              })}
-            >
-              {typeof screenHelmetProps.title === 'string' ? (
-                <div className={css.centerMainText}>
-                  {screenHelmetProps.title}
-                </div>
-              ) : (
-                screenHelmetProps.title
-              )}
+        <div
+          className={css.main({
+            noBorder: noBorder ? true : undefined,
+          })}
+        >
+          <div className={css.flex}>
+            <div className={css.left}>
+              {screenHelmetProps.closeButtonLocation === 'left' && closeButton}
+              {backButton}
+              {screenHelmetProps.appendLeft}
             </div>
             <div
-              className={css.centerMainEdge({
-                cupertino: cupertino ? true : undefined,
+              className={css.center({
+                android: android ? true : undefined,
               })}
-              onClick={props.onTopClick}
-            />
-          </div>
-          <div
-            className={css.right({
-              android: android ? true : undefined,
-            })}
-          >
-            {screenHelmetProps.appendRight}
-            {screenHelmetProps.closeButtonLocation === 'right' && closeButton}
+              ref={centerRef}
+            >
+              <div
+                className={css.centerMain({
+                  android: android ? true : undefined,
+                  androidAndIsLeft: android && isLeft ? true : undefined,
+                  cupertino: cupertino ? true : undefined,
+                })}
+              >
+                {typeof screenHelmetProps.title === 'string' ? (
+                  <div className={css.centerMainText}>
+                    {screenHelmetProps.title}
+                  </div>
+                ) : (
+                  screenHelmetProps.title
+                )}
+              </div>
+              <div
+                className={css.centerMainEdge({
+                  cupertino: cupertino ? true : undefined,
+                })}
+                onClick={props.onTopClick}
+              />
+            </div>
+            <div
+              className={css.right({
+                android: android ? true : undefined,
+              })}
+            >
+              {screenHelmetProps.appendRight}
+              {screenHelmetProps.closeButtonLocation === 'right' && closeButton}
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
 
 export default Navbar

--- a/packages/navigator/src/components/Navbar.tsx
+++ b/packages/navigator/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React, {
+  ReactElement,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useRef,
   useState,
 } from 'react'
@@ -15,7 +15,6 @@ import { useNavigator } from '../useNavigator'
 import * as css from './Navbar.css'
 import { useScreenHelmet } from './Stack.ContextScreenHelmet'
 import { usePlugins } from '../globalState/Plugins'
-import { useMounted } from '../hooks'
 
 interface INavbarProps {
   isNavbarVisible: boolean
@@ -27,214 +26,209 @@ interface INavbarProps {
   closeButtonAriaLabel: string
   onTopClick: () => void
   onClose: () => void
+  onMount: () => void
 }
-const Navbar = React.forwardRef<{ mounted: boolean }, INavbarProps>(
-  (props, ref) => {
-    const { pop } = useNavigator()
-    const { screenHelmetProps } = useScreenHelmet()
+const Navbar: React.FC<INavbarProps> = (props: INavbarProps): ReactElement => {
+  const { pop } = useNavigator()
+  const { screenHelmetProps } = useScreenHelmet()
 
-    const android = props.theme === 'Android'
-    const cupertino = props.theme === 'Cupertino'
+  const android = props.theme === 'Android'
+  const cupertino = props.theme === 'Cupertino'
 
-    const navbarHeight = android ? '-3.5rem' : '-2.75rem'
+  const [centerMainWidth, setCenterMainWidth] = useState<number | undefined>(
+    undefined
+  )
 
-    const [centerMainWidth, setCenterMainWidth] = useState<number | undefined>(
-      undefined
-    )
+  const navbarRef = useRef<HTMLDivElement>(null)
+  const centerRef = useRef<HTMLDivElement>(null)
 
-    const navbarRef = useRef<HTMLDivElement>(null)
-    const centerRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const $navbar = navbarRef.current
+    const $center = centerRef.current
 
-    useEffect(() => {
-      const $navbar = navbarRef.current
-      const $center = centerRef.current
-
-      const onResize = () => {
-        if (!$navbar || !$center) {
-          return
-        }
-
-        const screenWidth = $navbar.clientWidth
-
-        const leftWidth = $center.offsetLeft
-        const centerWidth = $center.clientWidth
-        const rightWidth = screenWidth - leftWidth - centerWidth
-
-        const sideMargin = Math.max(leftWidth, rightWidth)
-
-        setCenterMainWidth(screenWidth - 2 * sideMargin)
+    const onResize = () => {
+      if (!$navbar || !$center) {
+        return
       }
 
-      if (props.theme === 'Cupertino') {
-        onResize()
-        window.addEventListener('resize', onResize)
+      const screenWidth = $navbar.clientWidth
 
-        return () => {
-          window.removeEventListener('resize', onResize)
-        }
-      }
-    }, [screenHelmetProps])
+      const leftWidth = $center.offsetLeft
+      const centerWidth = $center.clientWidth
+      const rightWidth = screenWidth - leftWidth - centerWidth
 
-    const onBackClick = () => {
-      pop()
+      const sideMargin = Math.max(leftWidth, rightWidth)
+
+      setCenterMainWidth(screenWidth - 2 * sideMargin)
     }
 
-    const closeButton =
-      props.onClose &&
-      props.isRoot &&
-      !screenHelmetProps.noCloseButton &&
-      (screenHelmetProps.customCloseButton ? (
-        <a
-          className={css.closeButton}
-          role="text"
-          aria-label={props.closeButtonAriaLabel}
-          onClick={props.onClose}
-        >
-          {screenHelmetProps.customCloseButton}
-        </a>
-      ) : (
-        <a
-          className={css.closeButton}
-          role="text"
-          aria-label={props.closeButtonAriaLabel}
-          onClick={props.onClose}
-        >
-          <IconClose className={css.svgIcon} />
-        </a>
-      ))
+    if (props.theme === 'Cupertino') {
+      onResize()
+      window.addEventListener('resize', onResize)
 
-    const backButton =
-      !props.isRoot &&
-      !screenHelmetProps.noBackButton &&
-      (screenHelmetProps.customBackButton ? (
-        <a
-          className={css.backButton}
-          role="text"
-          aria-label={props.backButtonAriaLabel}
-          onClick={onBackClick}
-        >
-          {screenHelmetProps.customBackButton}
-        </a>
-      ) : (
-        <a
-          className={css.backButton}
-          role="text"
-          aria-label={props.backButtonAriaLabel}
-          onClick={onBackClick}
-        >
-          {props.theme === 'Cupertino' && props.isPresent ? (
-            <IconClose className={css.svgIcon} />
-          ) : (
-            <IconBack className={css.svgIcon} />
-          )}
-        </a>
-      ))
-
-    const isLeft = !!(
-      (screenHelmetProps.closeButtonLocation === 'left' && closeButton) ||
-      backButton ||
-      screenHelmetProps.appendLeft
-    )
-
-    const noBorder = screenHelmetProps.noBorder
-
-    const { lifecycleHooks } = usePlugins()
-
-    const onMountNavbar = useCallback(() => {
-      lifecycleHooks.forEach((hook) => {
-        const context = {
-          screenHelmetProps,
-        } as any
-        hook?.onMountNavbar?.(context)
-      })
-    }, [lifecycleHooks, screenHelmetProps])
-
-    const onUnmountNavbar = useCallback(() => {
-      lifecycleHooks.forEach((hook) => {
-        const context = {
-          screenHelmetProps,
-        } as any
-        hook?.onUnmountNavbar?.(context)
-      })
-    }, [lifecycleHooks, screenHelmetProps])
-
-    useEffect(() => {
-      onMountNavbar()
       return () => {
-        onUnmountNavbar()
+        window.removeEventListener('resize', onResize)
       }
-    }, [onMountNavbar, onUnmountNavbar])
+    }
+  }, [screenHelmetProps])
 
-    const mounted = useMounted({ afterTick: true })
-    useImperativeHandle(ref, () => ({ mounted }), [mounted])
+  const onBackClick = () => {
+    pop()
+  }
 
-    return (
+  const closeButton =
+    props.onClose &&
+    props.isRoot &&
+    !screenHelmetProps.noCloseButton &&
+    (screenHelmetProps.customCloseButton ? (
+      <a
+        className={css.closeButton}
+        role="text"
+        aria-label={props.closeButtonAriaLabel}
+        onClick={props.onClose}
+      >
+        {screenHelmetProps.customCloseButton}
+      </a>
+    ) : (
+      <a
+        className={css.closeButton}
+        role="text"
+        aria-label={props.closeButtonAriaLabel}
+        onClick={props.onClose}
+      >
+        <IconClose className={css.svgIcon} />
+      </a>
+    ))
+
+  const backButton =
+    !props.isRoot &&
+    !screenHelmetProps.noBackButton &&
+    (screenHelmetProps.customBackButton ? (
+      <a
+        className={css.backButton}
+        role="text"
+        aria-label={props.backButtonAriaLabel}
+        onClick={onBackClick}
+      >
+        {screenHelmetProps.customBackButton}
+      </a>
+    ) : (
+      <a
+        className={css.backButton}
+        role="text"
+        aria-label={props.backButtonAriaLabel}
+        onClick={onBackClick}
+      >
+        {props.theme === 'Cupertino' && props.isPresent ? (
+          <IconClose className={css.svgIcon} />
+        ) : (
+          <IconBack className={css.svgIcon} />
+        )}
+      </a>
+    ))
+
+  const isLeft = !!(
+    (screenHelmetProps.closeButtonLocation === 'left' && closeButton) ||
+    backButton ||
+    screenHelmetProps.appendLeft
+  )
+
+  const noBorder = screenHelmetProps.noBorder
+
+  const { lifecycleHooks } = usePlugins()
+
+  const onMountNavbar = useCallback(() => {
+    lifecycleHooks.forEach((hook) => {
+      const context = {
+        screenHelmetProps,
+      } as any
+      hook?.onMountNavbar?.(context)
+    })
+  }, [lifecycleHooks, screenHelmetProps])
+
+  const onUnmountNavbar = useCallback(() => {
+    lifecycleHooks.forEach((hook) => {
+      const context = {
+        screenHelmetProps,
+      } as any
+      hook?.onUnmountNavbar?.(context)
+    })
+  }, [lifecycleHooks, screenHelmetProps])
+
+  useEffect(() => {
+    onMountNavbar()
+    return () => {
+      onUnmountNavbar()
+    }
+  }, [onMountNavbar, onUnmountNavbar])
+
+  useEffect(() => {
+    props.onMount()
+  }, [props.onMount])
+
+  return (
+    <div
+      data-testid="navbar"
+      className={css.container({
+        cupertinoAndIsNotPresent:
+          cupertino && !props.isPresent ? true : undefined,
+      })}
+      ref={navbarRef}
+      style={assignInlineVars({
+        [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
+      })}
+    >
       <div
-        data-testid="navbar"
-        className={css.container({
-          cupertinoAndIsNotPresent:
-            cupertino && !props.isPresent ? true : undefined,
-        })}
-        ref={navbarRef}
-        style={assignInlineVars({
-          [vars.navbar.center.mainWidth]: `${centerMainWidth}px`,
-          [vars.navbar.animationDuration]: mounted ? '0.3s' : '0',
-          [vars.navbar.translateY]:
-            !mounted || props.isNavbarVisible ? '0' : navbarHeight,
+        className={css.main({
+          noBorder: noBorder ? true : undefined,
         })}
       >
-        <div
-          className={css.main({
-            noBorder: noBorder ? true : undefined,
-          })}
-        >
-          <div className={css.flex}>
-            <div className={css.left}>
-              {screenHelmetProps.closeButtonLocation === 'left' && closeButton}
-              {backButton}
-              {screenHelmetProps.appendLeft}
-            </div>
+        <div className={css.flex}>
+          <div className={css.left}>
+            {screenHelmetProps.closeButtonLocation === 'left' && closeButton}
+            {backButton}
+            {screenHelmetProps.appendLeft}
+          </div>
+          <div
+            className={css.center({
+              android: android ? true : undefined,
+            })}
+            ref={centerRef}
+          >
             <div
-              className={css.center({
+              className={css.centerMain({
                 android: android ? true : undefined,
-              })}
-              ref={centerRef}
-            >
-              <div
-                className={css.centerMain({
-                  android: android ? true : undefined,
-                  androidAndIsLeft: android && isLeft ? true : undefined,
-                  cupertino: cupertino ? true : undefined,
-                })}
-              >
-                {typeof screenHelmetProps.title === 'string' ? (
-                  <div className={css.centerMainText}>
-                    {screenHelmetProps.title}
-                  </div>
-                ) : (
-                  screenHelmetProps.title
-                )}
-              </div>
-              <div
-                className={css.centerMainEdge({
-                  cupertino: cupertino ? true : undefined,
-                })}
-                onClick={props.onTopClick}
-              />
-            </div>
-            <div
-              className={css.right({
-                android: android ? true : undefined,
+                androidAndIsLeft: android && isLeft ? true : undefined,
+                cupertino: cupertino ? true : undefined,
               })}
             >
-              {screenHelmetProps.appendRight}
-              {screenHelmetProps.closeButtonLocation === 'right' && closeButton}
+              {typeof screenHelmetProps.title === 'string' ? (
+                <div className={css.centerMainText}>
+                  {screenHelmetProps.title}
+                </div>
+              ) : (
+                screenHelmetProps.title
+              )}
             </div>
+            <div
+              className={css.centerMainEdge({
+                cupertino: cupertino ? true : undefined,
+              })}
+              onClick={props.onTopClick}
+            />
+          </div>
+          <div
+            className={css.right({
+              android: android ? true : undefined,
+            })}
+          >
+            {screenHelmetProps.appendRight}
+            {screenHelmetProps.closeButtonLocation === 'right' && closeButton}
           </div>
         </div>
       </div>
-    )
-  }
-)
+    </div>
+  )
+}
 
 export default Navbar

--- a/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
+++ b/packages/navigator/src/components/Stack.ContextScreenHelmet.tsx
@@ -35,7 +35,7 @@ const ContextScreenHelmet = createContext<{
 }>(null as any)
 
 export const ProviderScreenHelmet: React.FC = (props) => {
-  const [screenHelmetVisible, setScreenHelmetVisible] = useState(true)
+  const [screenHelmetVisible, setScreenHelmetVisible] = useState(false)
   const [screenHelmetProps, setScreenHelmetProps] =
     useDeepState<IScreenHelmetProps>(makeScreenHelmetDefaultProps())
 

--- a/packages/navigator/src/hooks/useMounted.ts
+++ b/packages/navigator/src/hooks/useMounted.ts
@@ -1,21 +1,35 @@
-import { useEffect, useReducer } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import { nextTick } from '../helpers'
 
 interface Options {
   afterTick?: boolean
+  manualMount?: boolean
 }
 
-export function useMounted(options?: Options) {
+export function useMounted(options?: Options): [boolean, () => void] {
   const [mounted, mount] = useReducer(() => true, false)
 
   useEffect(() => {
+    if (mounted) return
+
+    if (options?.manualMount) return
+
     if (options?.afterTick) {
       nextTick(() => mount())
       return
     }
 
     mount()
-  }, [mount, options])
+  }, [mount, options, mounted])
 
-  return mounted
+  const manualMount = useCallback(() => {
+    if (options?.afterTick) {
+      nextTick(() => mount())
+      return
+    }
+
+    mount()
+  }, [options, mount])
+
+  return [mounted, manualMount]
 }


### PR DESCRIPTION
- navbar 가 기본값으로 항상 보이는, 의도치 않은 파괴적 변환이 있어서 다시 [packages/navigator/src/components/Stack.ContextScreenHelmet.tsx](https://github.com/daangn/karrotframe/compare/fix/set-default-false-for-navbar?expand=1#diff-14a6683ebfbc980fccf040e4508485b7952d3377660b55e432a54f7e6eff3ec6) 의 screenHelmetVisible state 의 초기값을 false 로 변경했어요

- safari 환경에서 처음 렌더링 할 때는 navbar 가 transition 효과를 발생시키지 않도록 하기 위해 다음과 같이 작업했어요.
    - `useImperativeHandle` 을 사용해서 navbar.tsx 가 mounted 되었을 때 card.tsx 가 transition 이 가능한 상태가 되어요. 그래서 card.tsx 에서는 mounted 값 대신 activeTransition 라는 값으로 vars.navbar.animationDuration 을 설정해요.
    - `useImperativeHandle` 을 사용하기 위해 navbar 를 `forwardRef` 로 감쌌어요(이거 때문에 PR 에서는 코드를 많이 수정한 것처럼 나오네요..)
    - navbar.tsx 에서는 mounted 된 상태 이후에 translateY 값을 동적으로 설정하고, 그 이전에는 0으로 설정해서 transition 효과가 나타나지 않도록 변경했어요.
        - `   [vars.navbar.translateY]: !mounted || props.isNavbarVisible ? '0' : navbarHeight`
